### PR TITLE
Implement shape validation and display values

### DIFF
--- a/src/rainbow_tensor/shape.py
+++ b/src/rainbow_tensor/shape.py
@@ -4,11 +4,14 @@ This module turns user input into a validated ``tuple[int, ...]`` shape and
 generates the display values used when only a shape is provided.
 """
 
+SUPPORTED_NDIM = (1, 2, 3)
+
 
 def validate_shape(shape):
     """Validate a shape and return it as a ``tuple[int, ...]``.
 
-    The shape must be a non-empty sequence of positive integers.
+    The shape must be a non-empty sequence of positive integers with a
+    supported number of dimensions (1D, 2D, or 3D in this version).
     """
     if not isinstance(shape, tuple):
         try:
@@ -26,5 +29,11 @@ def validate_shape(shape):
             raise TypeError(f"shape dimensions must be integers, got {dim!r}")
         if dim <= 0:
             raise ValueError(f"shape dimensions must be positive, got {dim!r}")
+
+    if len(shape) not in SUPPORTED_NDIM:
+        raise ValueError(
+            f"only 1D, 2D, and 3D tensors are supported in this version, "
+            f"got {len(shape)} dimensions"
+        )
 
     return shape

--- a/src/rainbow_tensor/shape.py
+++ b/src/rainbow_tensor/shape.py
@@ -7,6 +7,22 @@ generates the display values used when only a shape is provided.
 SUPPORTED_NDIM = (1, 2, 3)
 
 
+def extract_shape(obj):
+    """Extract a validated shape from a tuple or an array-like object.
+
+    A tuple is treated as a literal shape. Any other object is expected to
+    expose a ``.shape`` attribute (for example a NumPy array). No tensor
+    library is imported, so this works for any object with ``.shape``.
+    """
+    if isinstance(obj, tuple):
+        raw = obj
+    elif hasattr(obj, "shape"):
+        raw = obj.shape
+    else:
+        raw = obj
+    return validate_shape(raw)
+
+
 def validate_shape(shape):
     """Validate a shape and return it as a ``tuple[int, ...]``.
 

--- a/src/rainbow_tensor/shape.py
+++ b/src/rainbow_tensor/shape.py
@@ -4,6 +4,8 @@ This module turns user input into a validated ``tuple[int, ...]`` shape and
 generates the display values used when only a shape is provided.
 """
 
+import itertools
+
 SUPPORTED_NDIM = (1, 2, 3)
 
 
@@ -53,3 +55,38 @@ def validate_shape(shape):
         )
 
     return shape
+
+
+def coordinates(shape):
+    """Yield every coordinate in row-major order for the given shape."""
+    return itertools.product(*[range(dim) for dim in shape])
+
+
+def flat_index(coord, shape):
+    """Return the row-major flat index of ``coord`` inside ``shape``."""
+    index = 0
+    for value, dim in zip(coord, shape):
+        index = index * dim + value
+    return index
+
+
+def generate_values(shape):
+    """Map every coordinate of ``shape`` to a sequential value from 0.
+
+    For shape ``(2, 2, 2)`` this produces the values 0 through 7 in
+    row-major order.
+    """
+    return {coord: flat_index(coord, shape) for coord in coordinates(shape)}
+
+
+def format_shape(shape):
+    """Format a shape the way Python prints a tuple, for example ``(2,)``."""
+    return str(tuple(shape))
+
+
+def format_shape_label(shape):
+    """Format a shape for an on-screen label without a trailing comma.
+
+    For shape ``(3,)`` this returns ``(3)`` rather than ``(3,)``.
+    """
+    return "(" + ", ".join(str(dim) for dim in shape) + ")"

--- a/src/rainbow_tensor/shape.py
+++ b/src/rainbow_tensor/shape.py
@@ -1,0 +1,30 @@
+"""Shape extraction and validation.
+
+This module turns user input into a validated ``tuple[int, ...]`` shape and
+generates the display values used when only a shape is provided.
+"""
+
+
+def validate_shape(shape):
+    """Validate a shape and return it as a ``tuple[int, ...]``.
+
+    The shape must be a non-empty sequence of positive integers.
+    """
+    if not isinstance(shape, tuple):
+        try:
+            shape = tuple(shape)
+        except TypeError as exc:
+            raise TypeError(
+                "shape must be a tuple of integers or an object with a .shape attribute"
+            ) from exc
+
+    if len(shape) == 0:
+        raise ValueError("shape must have at least one dimension, got an empty shape")
+
+    for dim in shape:
+        if isinstance(dim, bool) or not isinstance(dim, int):
+            raise TypeError(f"shape dimensions must be integers, got {dim!r}")
+        if dim <= 0:
+            raise ValueError(f"shape dimensions must be positive, got {dim!r}")
+
+    return shape

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -1,0 +1,35 @@
+"""Tests for shape extraction and validation."""
+
+import pytest
+
+from rainbow_tensor.shape import validate_shape
+
+
+@pytest.mark.parametrize("shape", [(3,), (2, 3), (2, 2, 2)])
+def test_valid_shapes(shape):
+    assert validate_shape(shape) == shape
+
+
+def test_reject_empty_shape():
+    with pytest.raises(ValueError):
+        validate_shape(())
+
+
+def test_reject_zero_dimension():
+    with pytest.raises(ValueError):
+        validate_shape((2, 0))
+
+
+def test_reject_negative_dimension():
+    with pytest.raises(ValueError):
+        validate_shape((2, -1))
+
+
+def test_reject_non_integer_dimension():
+    with pytest.raises(TypeError):
+        validate_shape((2, "3"))
+
+
+def test_reject_boolean_dimension():
+    with pytest.raises(TypeError):
+        validate_shape((2, True))

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -33,3 +33,8 @@ def test_reject_non_integer_dimension():
 def test_reject_boolean_dimension():
     with pytest.raises(TypeError):
         validate_shape((2, True))
+
+
+def test_reject_four_dimensions():
+    with pytest.raises(ValueError):
+        validate_shape((2, 2, 2, 2))

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -2,12 +2,30 @@
 
 import pytest
 
-from rainbow_tensor.shape import validate_shape
+from rainbow_tensor.shape import extract_shape, validate_shape
+
+
+class FakeArray:
+    def __init__(self, shape):
+        self.shape = shape
 
 
 @pytest.mark.parametrize("shape", [(3,), (2, 3), (2, 2, 2)])
 def test_valid_shapes(shape):
     assert validate_shape(shape) == shape
+
+
+def test_extract_shape_from_tuple():
+    assert extract_shape((2, 2, 2)) == (2, 2, 2)
+
+
+def test_extract_shape_from_array_like():
+    assert extract_shape(FakeArray((2, 2, 2))) == (2, 2, 2)
+
+
+def test_array_like_with_invalid_shape_uses_same_validation():
+    with pytest.raises(ValueError):
+        extract_shape(FakeArray((2, 0)))
 
 
 def test_reject_empty_shape():

--- a/tests/test_shape.py
+++ b/tests/test_shape.py
@@ -2,7 +2,14 @@
 
 import pytest
 
-from rainbow_tensor.shape import extract_shape, validate_shape
+from rainbow_tensor.shape import (
+    extract_shape,
+    flat_index,
+    format_shape,
+    format_shape_label,
+    generate_values,
+    validate_shape,
+)
 
 
 class FakeArray:
@@ -56,3 +63,27 @@ def test_reject_boolean_dimension():
 def test_reject_four_dimensions():
     with pytest.raises(ValueError):
         validate_shape((2, 2, 2, 2))
+
+
+def test_generate_values_for_three_dimensions():
+    values = generate_values((2, 2, 2))
+    assert values[(0, 0, 0)] == 0
+    assert values[(0, 0, 1)] == 1
+    assert values[(0, 1, 0)] == 2
+    assert values[(0, 1, 1)] == 3
+    assert values[(1, 0, 0)] == 4
+    assert values[(1, 1, 1)] == 7
+
+
+def test_flat_index_row_major():
+    assert flat_index((1, 0, 1), (2, 2, 2)) == 5
+
+
+def test_format_shape_uses_tuple_form():
+    assert format_shape((2,)) == "(2,)"
+    assert format_shape((2, 2, 2)) == "(2, 2, 2)"
+
+
+def test_format_shape_label_has_no_trailing_comma():
+    assert format_shape_label((3,)) == "(3)"
+    assert format_shape_label((2, 2, 2)) == "(2, 2, 2)"


### PR DESCRIPTION
Closes #4.

Adds the shape module.

Changes
- validate_shape rejects empty, non-integer, non-positive, and unsupported-rank shapes
- limit supported dimensions to 1D, 2D, and 3D
- extract_shape reads a .shape attribute from array-like objects without importing a tensor library
- generate_values produces sequential row-major display values
- add format helpers for shapes and tests covering all of the above