### PR TITLE
Implement static shape visualisation

### DIFF
--- a/src/rainbow_tensor/layout.py
+++ b/src/rainbow_tensor/layout.py
@@ -1,0 +1,114 @@
+"""Layout calculation.
+
+This module converts a tensor shape into 2D drawing coordinates. It knows
+nothing about SVG, so the same layout could be rendered by any backend.
+"""
+
+from dataclasses import dataclass, field
+
+from .shape import flat_index
+
+CELL = 40
+CELL_GAP = 6
+ROW_GAP = 6
+BLOCK_PAD = 12
+BLOCK_GAP = 28
+PADDING = 20
+
+
+@dataclass
+class Cell:
+    """A single tensor element placed on the canvas."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+    value: object
+    coord: tuple[int, ...]
+    selected: bool = False
+
+
+@dataclass
+class Block:
+    """A grouping rectangle around the rows of one axis-0 block."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+    index: int
+
+
+@dataclass
+class Layout:
+    """All drawing data for one tensor."""
+
+    cells: list[Cell] = field(default_factory=list)
+    blocks: list[Block] = field(default_factory=list)
+    width: float = 0.0
+    height: float = 0.0
+
+
+def _grid(shape: tuple[int, ...]) -> tuple[int, int, int]:
+    """Return ``(blocks, rows, cols)`` for a 1D, 2D, or 3D shape."""
+    ndim = len(shape)
+    if ndim == 1:
+        return 1, 1, shape[0]
+    if ndim == 2:
+        return 1, shape[0], shape[1]
+    return shape[0], shape[1], shape[2]
+
+
+def _coord(ndim: int, b: int, r: int, c: int) -> tuple[int, ...]:
+    """Build the real tensor coordinate for a grid position."""
+    if ndim == 1:
+        return (c,)
+    if ndim == 2:
+        return (r, c)
+    return (b, r, c)
+
+
+def build_layout(shape, selected=None, value_fn=None) -> Layout:
+    """Compute the layout for a tensor.
+
+    ``selected`` is an iterable of coordinates to mark as selected.
+    ``value_fn`` maps a coordinate to its display value. When it is ``None``
+    sequential row-major values starting at 0 are used.
+    """
+    selected_set = {tuple(coord) for coord in (selected or [])}
+    ndim = len(shape)
+    blocks, rows, cols = _grid(shape)
+
+    block_w = cols * CELL + (cols - 1) * CELL_GAP + 2 * BLOCK_PAD
+    block_h = rows * CELL + (rows - 1) * ROW_GAP + 2 * BLOCK_PAD
+
+    layout = Layout()
+    for b in range(blocks):
+        bx = PADDING + b * (block_w + BLOCK_GAP)
+        by = PADDING
+        layout.blocks.append(Block(bx, by, block_w, block_h, b))
+        for r in range(rows):
+            for c in range(cols):
+                x = bx + BLOCK_PAD + c * (CELL + CELL_GAP)
+                y = by + BLOCK_PAD + r * (CELL + ROW_GAP)
+                coord = _coord(ndim, b, r, c)
+                if value_fn is not None:
+                    value = value_fn(coord)
+                else:
+                    value = flat_index(coord, shape)
+                layout.cells.append(
+                    Cell(
+                        x=x,
+                        y=y,
+                        width=CELL,
+                        height=CELL,
+                        value=value,
+                        coord=coord,
+                        selected=coord in selected_set,
+                    )
+                )
+
+    layout.width = PADDING * 2 + blocks * block_w + (blocks - 1) * BLOCK_GAP
+    layout.height = PADDING * 2 + block_h
+    return layout

--- a/src/rainbow_tensor/notebook.py
+++ b/src/rainbow_tensor/notebook.py
@@ -1,17 +1,82 @@
 """Notebook display layer.
 
 This module exposes the public functions ``show_shape`` and ``show_index``.
-The real rendering is added in later changes. For now these are placeholders
-so the public API can be imported and wired up.
+Each returns a small object that renders as SVG in a notebook and stays
+inspectable in plain Python, so the package is testable outside a notebook.
 """
+
+from .render_svg import render_svg
+from .shape import extract_shape, format_shape_label
+
+
+class TensorVisual:
+    """A rendered tensor visualisation.
+
+    The ``svg`` attribute holds the SVG string. In a notebook the object is
+    shown as an image through ``_repr_svg_``. Outside a notebook the same
+    string is available for inspection and testing.
+    """
+
+    def __init__(self, svg, shape, selected=None, result=None, explanation=None):
+        self.svg = svg
+        self.shape = shape
+        self.selected = selected
+        self.result_shape = result
+        self.explanation = explanation or []
+
+    def _repr_svg_(self):
+        return self.svg
+
+    def __str__(self):
+        return self.svg
+
+
+def _value_fn_for(obj):
+    """Build a coordinate to value function for array-like input.
+
+    A tuple carries no values, so generated values are used. Any object with
+    a ``.shape`` attribute is read by coordinate, which covers NumPy arrays
+    and any compatible array-like without importing a tensor library.
+    """
+    if isinstance(obj, tuple):
+        return None
+    if not hasattr(obj, "shape"):
+        return None
+
+    def value_fn(coord):
+        value = obj[coord]
+        item = getattr(value, "item", None)
+        if callable(item):
+            return item()
+        return value
+
+    return value_fn
+
+
+def _display(visual):
+    """Display a visual in IPython when available, otherwise do nothing."""
+    try:
+        from IPython.display import display
+    except Exception:
+        return
+    display(visual)
 
 
 def show_shape(shape):
     """Visualise the structure of a tensor shape.
 
-    Not implemented yet.
+    ``shape`` may be a tuple such as ``(2, 2, 2)`` or an array-like object
+    with a ``.shape`` attribute such as a NumPy array. The tensor is rendered
+    as SVG and displayed in a notebook. The returned :class:`TensorVisual`
+    also exposes the SVG string.
     """
-    raise NotImplementedError("show_shape is not implemented yet")
+    normalized = extract_shape(shape)
+    value_fn = _value_fn_for(shape)
+    label = f"Shape {format_shape_label(normalized)}"
+    svg = render_svg(normalized, value_fn=value_fn, label=label)
+    visual = TensorVisual(svg, normalized)
+    _display(visual)
+    return visual
 
 
 def show_index(tensor_or_shape, index):

--- a/src/rainbow_tensor/render_svg.py
+++ b/src/rainbow_tensor/render_svg.py
@@ -1,0 +1,77 @@
+"""SVG rendering.
+
+This module turns a :class:`~rainbow_tensor.layout.Layout` into an SVG
+string. It draws the tensor blocks, cells, values, and a label.
+"""
+
+from .layout import build_layout
+
+CELL_FILL = "#ffffff"
+CELL_STROKE = "#94a3b8"
+BLOCK_STROKE = "#cbd5e1"
+TEXT_COLOR = "#0f172a"
+LABEL_COLOR = "#334155"
+
+LABEL_HEIGHT = 28
+LINE_HEIGHT = 20
+FONT_FAMILY = "ui-monospace, Menlo, Consolas, monospace"
+
+
+def escape(text):
+    """Escape a value so it is safe inside SVG text and attributes."""
+    return (
+        str(text)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+    )
+
+
+def svg_document(content, width, height):
+    """Wrap rendered elements in a complete SVG document."""
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'width="{width:.0f}" height="{height:.0f}" '
+        f'viewBox="0 0 {width:.0f} {height:.0f}" '
+        f'font-family="{FONT_FAMILY}">'
+        f"{content}"
+        f"</svg>"
+    )
+
+
+def render_svg(shape, value_fn=None, label=""):
+    """Render a tensor shape as an SVG string."""
+    layout = build_layout(shape, value_fn=value_fn)
+    parts = []
+
+    for block in layout.blocks:
+        parts.append(
+            f'<rect x="{block.x:.0f}" y="{block.y:.0f}" '
+            f'width="{block.width:.0f}" height="{block.height:.0f}" '
+            f'rx="8" fill="none" stroke="{BLOCK_STROKE}" stroke-width="1.5"/>'
+        )
+
+    for cell in layout.cells:
+        cx = cell.x + cell.width / 2
+        cy = cell.y + cell.height / 2
+        parts.append(
+            f'<rect x="{cell.x:.0f}" y="{cell.y:.0f}" '
+            f'width="{cell.width:.0f}" height="{cell.height:.0f}" '
+            f'rx="6" fill="{CELL_FILL}" stroke="{CELL_STROKE}" stroke-width="1.5"/>'
+            f'<text x="{cx:.0f}" y="{cy:.0f}" text-anchor="middle" '
+            f'dominant-baseline="central" font-size="15" '
+            f'fill="{TEXT_COLOR}">{escape(cell.value)}</text>'
+        )
+
+    width = layout.width
+    y = layout.height + LABEL_HEIGHT
+    if label:
+        parts.append(
+            f'<text x="20" y="{y:.0f}" font-size="16" font-weight="600" '
+            f'fill="{LABEL_COLOR}">{escape(label)}</text>'
+        )
+        y += LINE_HEIGHT
+
+    height = y + 16
+    return svg_document("".join(parts), width, height)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,48 @@
+"""Tests for layout calculation."""
+
+from rainbow_tensor.layout import build_layout
+
+
+def test_one_dimensional_layout_cell_count():
+    layout = build_layout((3,))
+    assert len(layout.cells) == 3
+
+
+def test_two_dimensional_layout_cell_count():
+    layout = build_layout((2, 3))
+    assert len(layout.cells) == 6
+
+
+def test_three_dimensional_layout_structure():
+    layout = build_layout((2, 2, 2))
+    assert len(layout.blocks) == 2
+    assert len(layout.cells) == 8
+    by_value = {cell.value: cell.coord for cell in layout.cells}
+    assert by_value[0] == (0, 0, 0)
+    assert by_value[1] == (0, 0, 1)
+    assert by_value[3] == (0, 1, 1)
+    assert by_value[4] == (1, 0, 0)
+    assert by_value[7] == (1, 1, 1)
+
+
+def test_cells_do_not_overlap():
+    layout = build_layout((2, 3))
+    boxes = [(c.x, c.y, c.width, c.height) for c in layout.cells]
+    for i in range(len(boxes)):
+        for j in range(i + 1, len(boxes)):
+            ax, ay, aw, ah = boxes[i]
+            bx, by, bw, bh = boxes[j]
+            separated = ax + aw <= bx or bx + bw <= ax or ay + ah <= by or by + bh <= ay
+            assert separated
+
+
+def test_value_fn_overrides_generated_values():
+    layout = build_layout((3,), value_fn=lambda coord: coord[0] * 10)
+    values = sorted(cell.value for cell in layout.cells)
+    assert values == [0, 10, 20]
+
+
+def test_selected_coordinates_are_marked():
+    layout = build_layout((2, 2, 2), selected=[(0, 0, 1)])
+    selected = [cell.coord for cell in layout.cells if cell.selected]
+    assert selected == [(0, 0, 1)]

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -1,0 +1,39 @@
+"""Tests for the notebook display layer."""
+
+import pytest
+
+from rainbow_tensor import show_index, show_shape
+from rainbow_tensor.notebook import TensorVisual
+
+
+class FakeArray:
+    def __init__(self, shape, values):
+        self.shape = shape
+        self._values = values
+
+    def __getitem__(self, coord):
+        return self._values[coord]
+
+
+def test_show_shape_returns_visual_with_svg():
+    visual = show_shape((2, 2, 2))
+    assert isinstance(visual, TensorVisual)
+    assert visual.svg.startswith("<svg")
+    assert visual.shape == (2, 2, 2)
+
+
+def test_show_shape_repr_svg_matches_svg():
+    visual = show_shape((3,))
+    assert visual._repr_svg_() == visual.svg
+    assert "Shape (3)" in visual.svg
+
+
+def test_show_shape_uses_array_values():
+    array = FakeArray((3,), {(0,): 10, (1,): 20, (2,): 30})
+    visual = show_shape(array)
+    assert ">20<" in visual.svg
+
+
+def test_show_index_not_implemented_yet():
+    with pytest.raises(NotImplementedError):
+        show_index((2, 2, 2), (0, slice(None), 1))

--- a/tests/test_render_svg.py
+++ b/tests/test_render_svg.py
@@ -1,0 +1,30 @@
+"""Tests for SVG rendering."""
+
+from rainbow_tensor.render_svg import escape, render_svg, svg_document
+
+
+def test_escape_replaces_markup_characters():
+    assert escape("<a & b>") == "&lt;a &amp; b&gt;"
+
+
+def test_svg_document_is_well_formed():
+    doc = svg_document("<rect/>", 100, 50)
+    assert doc.startswith("<svg")
+    assert doc.endswith("</svg>")
+    assert 'width="100"' in doc
+
+
+def test_render_svg_starts_with_svg_tag():
+    svg = render_svg((3,), label="Shape (3)")
+    assert svg.startswith("<svg")
+
+
+def test_render_svg_includes_label_and_values():
+    svg = render_svg((2, 2, 2), label="Shape (2, 2, 2)")
+    assert "Shape (2, 2, 2)" in svg
+    assert ">7<" in svg
+
+
+def test_render_svg_draws_one_rect_per_cell_plus_blocks():
+    svg = render_svg((2, 2, 2))
+    assert svg.count("<rect") == 8 + 2


### PR DESCRIPTION
Closes #6.

Adds layout calculation, an SVG renderer, and the show_shape function.

Changes
- layout.py computes block, row, and cell positions for 1D, 2D, and 3D shapes with no overlap
- render_svg.py escapes text, wraps a valid SVG document, and draws blocks, cells, values, and a label
- notebook.py implements show_shape and returns a TensorVisual that renders in notebooks and stays inspectable
- tests cover layout, rendering, and the public show_shape path