### PR TITLE
Implement index visualisation

### DIFF
--- a/src/rainbow_tensor/indexing.py
+++ b/src/rainbow_tensor/indexing.py
@@ -1,0 +1,47 @@
+"""Index validation, slice expansion, and selection computation.
+
+This module validates indexing expressions, expands slices into integer
+positions, computes the selected coordinates, and computes the result shape
+after indexing.
+"""
+
+
+def validate_index(index, shape):
+    """Validate an index tuple against a tensor shape.
+
+    The index must be a tuple whose length matches the tensor rank. Each
+    entry must be a non-negative in-range integer or a slice. Negative
+    integers and other entry types are rejected in this version.
+    """
+    if not isinstance(index, tuple):
+        raise TypeError(
+            f"index must be a tuple, got {type(index).__name__}. "
+            f"For a single axis use a one element tuple such as (0,)"
+        )
+
+    if len(index) != len(shape):
+        raise ValueError(
+            f"index length {len(index)} does not match tensor rank {len(shape)}"
+        )
+
+    for axis, (entry, size) in enumerate(zip(index, shape)):
+        if isinstance(entry, bool):
+            raise TypeError(f"axis {axis}: boolean indices are not supported")
+        if isinstance(entry, int):
+            if entry < 0:
+                raise IndexError(
+                    f"axis {axis}: negative indices are not supported, got {entry}"
+                )
+            if entry >= size:
+                raise IndexError(
+                    f"axis {axis}: integer index {entry} is out of range for size {size}"
+                )
+        elif isinstance(entry, slice):
+            continue
+        else:
+            raise TypeError(
+                f"axis {axis}: unsupported index entry {entry!r}. "
+                f"Only integers and slices are supported"
+            )
+
+    return index

--- a/src/rainbow_tensor/indexing.py
+++ b/src/rainbow_tensor/indexing.py
@@ -7,6 +7,8 @@ after indexing.
 
 import itertools
 
+from .shape import format_shape
+
 
 def validate_index(index, shape):
     """Validate an index tuple against a tensor shape.
@@ -64,3 +66,59 @@ def selected_coordinates(shape, index):
         else:
             axes.append(expand_slice(entry, size))
     return list(itertools.product(*axes))
+
+
+def result_shape(shape, index):
+    """Compute the result shape after indexing.
+
+    Integer entries remove their axis. Slice entries keep their axis with a
+    size equal to the number of selected positions.
+    """
+    validate_index(index, shape)
+    out = []
+    for entry, size in zip(index, shape):
+        if isinstance(entry, slice):
+            out.append(len(expand_slice(entry, size)))
+    return tuple(out)
+
+
+def format_slice(sl):
+    """Format a slice the way it would appear in indexing notation."""
+    if sl.start is None and sl.stop is None and sl.step is None:
+        return ":"
+    start = "" if sl.start is None else str(sl.start)
+    stop = "" if sl.stop is None else str(sl.stop)
+    if sl.step is None:
+        return f"{start}:{stop}"
+    return f"{start}:{stop}:{sl.step}"
+
+
+def format_index(index):
+    """Format an index tuple as a readable string such as ``0, :, 1``."""
+    parts = []
+    for entry in index:
+        if isinstance(entry, slice):
+            parts.append(format_slice(entry))
+        else:
+            parts.append(str(entry))
+    return ", ".join(parts)
+
+
+def explain_index(shape, index):
+    """Build the lines explaining how an index transforms a shape."""
+    validate_index(index, shape)
+    lines = [
+        f"Original shape: {format_shape(shape)}",
+        f"Index: {format_index(index)}",
+        f"Result shape: {format_shape(result_shape(shape, index))}",
+    ]
+    for axis, entry in enumerate(index):
+        if isinstance(entry, int):
+            lines.append(
+                f"Axis {axis} is removed because integer index {entry} is used."
+            )
+        else:
+            lines.append(
+                f"Axis {axis} is kept because slice {format_slice(entry)} is used."
+            )
+    return lines

--- a/src/rainbow_tensor/indexing.py
+++ b/src/rainbow_tensor/indexing.py
@@ -5,6 +5,8 @@ positions, computes the selected coordinates, and computes the result shape
 after indexing.
 """
 
+import itertools
+
 
 def validate_index(index, shape):
     """Validate an index tuple against a tensor shape.
@@ -45,3 +47,20 @@ def validate_index(index, shape):
             )
 
     return index
+
+
+def expand_slice(sl, size):
+    """Expand a slice into the list of integer positions it selects."""
+    return list(range(*sl.indices(size)))
+
+
+def selected_coordinates(shape, index):
+    """Compute every coordinate selected by ``index`` in row-major order."""
+    validate_index(index, shape)
+    axes = []
+    for entry, size in zip(index, shape):
+        if isinstance(entry, int):
+            axes.append([entry])
+        else:
+            axes.append(expand_slice(entry, size))
+    return list(itertools.product(*axes))

--- a/src/rainbow_tensor/notebook.py
+++ b/src/rainbow_tensor/notebook.py
@@ -5,6 +5,13 @@ Each returns a small object that renders as SVG in a notebook and stays
 inspectable in plain Python, so the package is testable outside a notebook.
 """
 
+from .indexing import (
+    explain_index,
+    format_index,
+    result_shape,
+    selected_coordinates,
+    validate_index,
+)
 from .render_svg import render_svg
 from .shape import extract_shape, format_shape_label
 
@@ -82,6 +89,28 @@ def show_shape(shape):
 def show_index(tensor_or_shape, index):
     """Visualise how an index selects elements from a tensor.
 
-    Not implemented yet.
+    ``tensor_or_shape`` may be a shape tuple or an array-like object with a
+    ``.shape`` attribute. ``index`` must be a tuple of integers and slices
+    whose length matches the tensor rank. Selected elements are highlighted,
+    unselected elements stay visible but de-emphasised, and an explanation of
+    the result shape is drawn below the tensor.
     """
-    raise NotImplementedError("show_index is not implemented yet")
+    normalized = extract_shape(tensor_or_shape)
+    validate_index(index, normalized)
+    selected = selected_coordinates(normalized, index)
+    result = result_shape(normalized, index)
+    explanation = explain_index(normalized, index)
+    value_fn = _value_fn_for(tensor_or_shape)
+    label = f"Index [{format_index(index)}]"
+    svg = render_svg(
+        normalized,
+        selected=selected,
+        value_fn=value_fn,
+        label=label,
+        explanation=explanation,
+    )
+    visual = TensorVisual(
+        svg, normalized, selected=selected, result=result, explanation=explanation
+    )
+    _display(visual)
+    return visual

--- a/src/rainbow_tensor/render_svg.py
+++ b/src/rainbow_tensor/render_svg.py
@@ -1,7 +1,9 @@
 """SVG rendering.
 
 This module turns a :class:`~rainbow_tensor.layout.Layout` into an SVG
-string. It draws the tensor blocks, cells, values, and a label.
+string. It draws the tensor blocks, cells, values, and a label. Selected
+cells are highlighted and, when a selection exists, the unselected cells are
+de-emphasised but still readable. An optional explanation is drawn below.
 """
 
 from .layout import build_layout
@@ -9,8 +11,11 @@ from .layout import build_layout
 CELL_FILL = "#ffffff"
 CELL_STROKE = "#94a3b8"
 BLOCK_STROKE = "#cbd5e1"
+HIGHLIGHT_FILL = "#fde68a"
+HIGHLIGHT_STROKE = "#d97706"
 TEXT_COLOR = "#0f172a"
 LABEL_COLOR = "#334155"
+DIM_OPACITY = 0.3
 
 LABEL_HEIGHT = 28
 LINE_HEIGHT = 20
@@ -40,38 +45,75 @@ def svg_document(content, width, height):
     )
 
 
-def render_svg(shape, value_fn=None, label=""):
-    """Render a tensor shape as an SVG string."""
-    layout = build_layout(shape, value_fn=value_fn)
+def render_svg(shape, selected=None, value_fn=None, label="", explanation=None):
+    """Render a tensor as an SVG string.
+
+    ``selected`` is an iterable of selected coordinates. ``value_fn`` maps a
+    coordinate to its display value. ``label`` is drawn under the tensor and
+    ``explanation`` is an optional list of lines drawn below the label.
+    """
+    explanation = explanation or []
+    selected_list = list(selected or [])
+    has_selection = len(selected_list) > 0
+    layout = build_layout(shape, selected=selected_list, value_fn=value_fn)
+
     parts = []
 
     for block in layout.blocks:
+        if has_selection:
+            block_selected = any(
+                cell.selected for cell in layout.cells if cell.coord[0] == block.index
+            )
+            opacity = 1.0 if block_selected else DIM_OPACITY
+        else:
+            opacity = 1.0
         parts.append(
             f'<rect x="{block.x:.0f}" y="{block.y:.0f}" '
             f'width="{block.width:.0f}" height="{block.height:.0f}" '
-            f'rx="8" fill="none" stroke="{BLOCK_STROKE}" stroke-width="1.5"/>'
+            f'rx="8" fill="none" stroke="{BLOCK_STROKE}" stroke-width="1.5" '
+            f'opacity="{opacity:.2f}"/>'
         )
 
     for cell in layout.cells:
+        if cell.selected:
+            fill = HIGHLIGHT_FILL
+            stroke = HIGHLIGHT_STROKE
+            opacity = 1.0
+            weight = "700"
+        else:
+            fill = CELL_FILL
+            stroke = CELL_STROKE
+            opacity = DIM_OPACITY if has_selection else 1.0
+            weight = "400"
         cx = cell.x + cell.width / 2
         cy = cell.y + cell.height / 2
         parts.append(
+            f'<g opacity="{opacity:.2f}">'
             f'<rect x="{cell.x:.0f}" y="{cell.y:.0f}" '
             f'width="{cell.width:.0f}" height="{cell.height:.0f}" '
-            f'rx="6" fill="{CELL_FILL}" stroke="{CELL_STROKE}" stroke-width="1.5"/>'
+            f'rx="6" fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>'
             f'<text x="{cx:.0f}" y="{cy:.0f}" text-anchor="middle" '
-            f'dominant-baseline="central" font-size="15" '
+            f'dominant-baseline="central" font-size="15" font-weight="{weight}" '
             f'fill="{TEXT_COLOR}">{escape(cell.value)}</text>'
+            f"</g>"
         )
 
     width = layout.width
     y = layout.height + LABEL_HEIGHT
+
     if label:
         parts.append(
             f'<text x="20" y="{y:.0f}" font-size="16" font-weight="600" '
             f'fill="{LABEL_COLOR}">{escape(label)}</text>'
         )
         y += LINE_HEIGHT
+
+    for line in explanation:
+        y += LINE_HEIGHT - 4
+        parts.append(
+            f'<text x="20" y="{y:.0f}" font-size="13" fill="{LABEL_COLOR}">'
+            f"{escape(line)}</text>"
+        )
 
     height = y + 16
     return svg_document("".join(parts), width, height)

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -1,0 +1,39 @@
+"""Tests for index validation, slice expansion, and selection."""
+
+import pytest
+
+from rainbow_tensor.indexing import validate_index
+
+
+def test_valid_indices():
+    assert validate_index((0,), (2,)) == (0,)
+    assert validate_index((slice(None),), (2,)) == (slice(None),)
+    assert validate_index((0, slice(None), 1), (2, 2, 2)) == (0, slice(None), 1)
+
+
+@pytest.mark.parametrize("index", ["0, :, 1", [0, slice(None), 1]])
+def test_reject_non_tuple_index(index):
+    with pytest.raises(TypeError):
+        validate_index(index, (2, 2, 2))
+
+
+def test_reject_none_entry():
+    with pytest.raises(TypeError):
+        validate_index((0, None, 1), (2, 2, 2))
+
+
+def test_reject_wrong_length():
+    with pytest.raises(ValueError):
+        validate_index((0, slice(None)), (2, 2, 2))
+
+
+def test_reject_out_of_range_integer():
+    with pytest.raises(IndexError):
+        validate_index((2, slice(None), 1), (2, 2, 2))
+    with pytest.raises(IndexError):
+        validate_index((0, slice(None), 2), (2, 2, 2))
+
+
+def test_reject_negative_integer():
+    with pytest.raises(IndexError):
+        validate_index((-1, slice(None), 1), (2, 2, 2))

--- a/tests/test_indexing.py
+++ b/tests/test_indexing.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from rainbow_tensor.indexing import validate_index
+from rainbow_tensor.indexing import (
+    expand_slice,
+    selected_coordinates,
+    validate_index,
+)
 
 
 def test_valid_indices():
@@ -37,3 +41,18 @@ def test_reject_out_of_range_integer():
 def test_reject_negative_integer():
     with pytest.raises(IndexError):
         validate_index((-1, slice(None), 1), (2, 2, 2))
+
+
+def test_expand_slice():
+    assert expand_slice(slice(None), 4) == [0, 1, 2, 3]
+    assert expand_slice(slice(1, 3), 4) == [1, 2]
+    assert expand_slice(slice(0, 4, 2), 4) == [0, 2]
+
+
+def test_selected_coordinates():
+    selected = selected_coordinates((2, 2, 2), (0, slice(None), 1))
+    assert selected == [(0, 0, 1), (0, 1, 1)]
+
+
+def test_selected_coordinates_one_dimension():
+    assert selected_coordinates((3,), (slice(1, 3),)) == [(1,), (2,)]

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -34,6 +34,35 @@ def test_show_shape_uses_array_values():
     assert ">20<" in visual.svg
 
 
-def test_show_index_not_implemented_yet():
-    with pytest.raises(NotImplementedError):
-        show_index((2, 2, 2), (0, slice(None), 1))
+def test_show_index_computes_selection_and_result_shape():
+    visual = show_index((2, 2, 2), (0, slice(None), 1))
+    assert visual.selected == [(0, 0, 1), (0, 1, 1)]
+    assert visual.result_shape == (2,)
+    assert "Result shape: (2,)" in visual.svg
+
+
+def test_show_index_highlights_selected_values():
+    visual = show_index((2, 2, 2), (0, slice(None), 1))
+    assert "#fde68a" in visual.svg
+    assert visual.svg.startswith("<svg")
+
+
+def test_show_index_uses_array_values():
+    values = {}
+    for i in range(2):
+        for j in range(2):
+            for k in range(2):
+                values[(i, j, k)] = (i * 4 + j * 2 + k) * 100
+    array = FakeArray((2, 2, 2), values)
+    visual = show_index(array, (0, slice(None), 1))
+    assert ">100<" in visual.svg
+    assert ">300<" in visual.svg
+
+
+def test_show_index_with_numpy_array():
+    np = pytest.importorskip("numpy")
+    x = np.arange(8).reshape(2, 2, 2)
+    visual = show_index(x, (0, slice(None), 1))
+    assert ">1<" in visual.svg
+    assert ">3<" in visual.svg
+    assert visual.result_shape == (2,)

--- a/tests/test_render_svg.py
+++ b/tests/test_render_svg.py
@@ -28,3 +28,25 @@ def test_render_svg_includes_label_and_values():
 def test_render_svg_draws_one_rect_per_cell_plus_blocks():
     svg = render_svg((2, 2, 2))
     assert svg.count("<rect") == 8 + 2
+
+
+def test_render_svg_highlights_selected_cells():
+    selected = [(0, 0, 1), (0, 1, 1)]
+    svg = render_svg((2, 2, 2), selected=selected)
+    assert "#fde68a" in svg
+
+
+def test_render_svg_dims_unselected_cells_when_selection_exists():
+    svg = render_svg((2, 2, 2), selected=[(0, 0, 1)])
+    assert 'opacity="0.30"' in svg
+
+
+def test_render_svg_includes_explanation_lines():
+    svg = render_svg(
+        (2, 2, 2),
+        selected=[(0, 0, 1), (0, 1, 1)],
+        label="Index [0, :, 1]",
+        explanation=["Result shape: (2,)"],
+    )
+    assert "Result shape: (2,)" in svg
+    assert "Index [0, :, 1]" in svg

--- a/tests/test_result_shape.py
+++ b/tests/test_result_shape.py
@@ -1,0 +1,36 @@
+"""Tests for result shape, index formatting, and explanation."""
+
+from rainbow_tensor.indexing import (
+    explain_index,
+    format_index,
+    format_slice,
+    result_shape,
+)
+
+
+def test_result_shape_examples():
+    assert result_shape((2, 2, 2), (0, slice(None), 1)) == (2,)
+    assert result_shape((2, 2, 2), (slice(None), 1, slice(None))) == (2, 2)
+    assert result_shape((2, 2, 2), (slice(None), slice(0, 1), slice(None))) == (2, 1, 2)
+
+
+def test_format_slice():
+    assert format_slice(slice(None)) == ":"
+    assert format_slice(slice(1, 3)) == "1:3"
+    assert format_slice(slice(0, 4, 2)) == "0:4:2"
+
+
+def test_format_index():
+    assert format_index((0, slice(None), 1)) == "0, :, 1"
+    assert format_index((slice(None), slice(1, 3))) == ":, 1:3"
+    assert format_index((slice(0, 4, 2),)) == "0:4:2"
+
+
+def test_explain_index():
+    lines = explain_index((2, 2, 2), (0, slice(None), 1))
+    assert lines[0] == "Original shape: (2, 2, 2)"
+    assert lines[1] == "Index: 0, :, 1"
+    assert lines[2] == "Result shape: (2,)"
+    assert lines[3] == "Axis 0 is removed because integer index 0 is used."
+    assert lines[4] == "Axis 1 is kept because slice : is used."
+    assert lines[5] == "Axis 2 is removed because integer index 1 is used."


### PR DESCRIPTION
Closes #8.

Adds indexing support and the show_index function.

Changes
- validate_index checks tuple form, rank, integer bounds, and rejects negatives and unsupported entries
- expand_slice and selected_coordinates compute the selected positions in row-major order
- result_shape, format_slice, format_index, and explain_index describe the indexing outcome
- render_svg highlights selected cells, de-emphasises the rest, and draws an explanation
- show_index extracts the shape, validates, selects, renders, and displays, using array values when available
- tests cover validation, selection, result shape, rendering, and the public path including a NumPy case