### PR TITLE
Add documentation, examples, and build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install
+        run: pip install -e ".[dev]"
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest
+      - name: Build
+        run: python -m build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+## 0.1.0
+
+First version.
+
+### Added
+
+- Static SVG visualisation of tensor shape for 1D, 2D, and 3D tensors through `show_shape`
+- Static SVG visualisation of basic indexing through `show_index`, with highlighted selections and de-emphasised context
+- A plain text explanation of the result shape and of which axes are kept or removed
+- Support for shape tuples and array-like objects with a `.shape` attribute, including NumPy arrays
+- Integer indexing and basic slicing with `slice(None)`, `slice(start, stop)`, and `slice(start, stop, step)`
+
+### Known limitations
+
+- Interactive widgets are not included in this version
+- Advanced indexing, boolean masks, `None`, `newaxis`, and ellipsis are not supported
+- Tensors of 4D or higher are not supported
+
+### Planned next steps
+
+- Interactive controls in a notebook widget
+- Higher dimensional layouts
+- Optional support for more tensor libraries through shape duck typing

--- a/README.md
+++ b/README.md
@@ -1,52 +1,91 @@
 # rainbow-tensor
 
-A Python package designed specifically for IPython/Jupyter notebook environments with numpy support.
+Visualise tensor shape, indexing, and slicing as SVG inside IPython and Jupyter notebooks.
+
+rainbow-tensor is made for people who are learning how a tensor is structured and how an indexing expression selects elements. It draws the tensor as nested blocks, rows, and cells, then highlights exactly which elements an index picks out.
 
 ## Features
 
-- Can only be used in IPython environments (Jupyter notebooks, IPython shell)
-- Automatically includes numpy as a dependency
-- Simple and lightweight
+- Static SVG output that stays sharp at any zoom level in a notebook
+- Shape visualisation for 1D, 2D, and 3D tensors
+- Index visualisation with highlighted selections and a plain text explanation
+- Works with shape tuples and with array-like objects that expose a `.shape` attribute, such as NumPy arrays
+- No tensor library is imported by the core, so the package stays lightweight
 
 ## Installation
 
-Install the package using pip:
-
-```bash
-pip install rainbow-tensor
-```
-
-Or install from source:
+Install from source for development.
 
 ```bash
 git clone https://github.com/Niox1337/rainbow-tensor.git
 cd rainbow-tensor
-pip install .
+pip install -e .
+```
+
+Install with the development tools (pytest, ruff, build).
+
+```bash
+pip install -e ".[dev]"
 ```
 
 ## Usage
 
-This package can **only** be used in IPython/Jupyter notebook environments. If you try to import it in a regular Python script, it will raise an error.
+Run the examples in a Jupyter notebook or an IPython shell so the SVG is displayed.
 
-**In a Jupyter notebook or IPython shell:**
-
-```python
-import rainbow_tensor
-# numpy is available through the package
-print(rainbow_tensor.np.array([1, 2, 3]))
-```
-
-**In a regular Python script (this will fail):**
+Visualise a shape.
 
 ```python
-import rainbow_tensor  # RuntimeError: rainbow-tensor can only be used in IPython environments
+from rainbow_tensor import show_shape
+
+show_shape((2, 2, 2))
 ```
 
-## Requirements
+Visualise how an index selects elements.
 
-- Python >= 3.6
-- numpy >= 1.19.0
-- ipython >= 7.0.0
+```python
+from rainbow_tensor import show_index
+
+show_index((2, 2, 2), (0, slice(None), 1))
+```
+
+For the shape `(2, 2, 2)` the index `(0, slice(None), 1)` selects the values `1` and `3`, the selected coordinates are `(0, 0, 1)` and `(0, 1, 1)`, and the result shape is `(2,)`.
+
+Use a real NumPy array to display its actual values.
+
+```python
+import numpy as np
+from rainbow_tensor import show_shape, show_index
+
+x = np.arange(8).reshape(2, 2, 2)
+show_shape(x)
+show_index(x, (0, slice(None), 1))
+```
+
+Each function returns a small result object. Its `svg` attribute holds the SVG string, so the package can be inspected and tested outside a notebook.
+
+## Supported
+
+- 1D, 2D, and 3D tensors
+- Shape tuples and array-like objects with a `.shape` attribute
+- Integer indexing
+- Basic slicing with `slice(None)`, `slice(start, stop)`, and `slice(start, stop, step)`
+
+## Unsupported in the first version
+
+- Advanced NumPy indexing
+- Boolean masks
+- `None` and `newaxis`
+- Ellipsis
+- 4D or higher tensors
+- Interactive controls and animation
+
+## Development
+
+```bash
+pytest
+ruff check .
+python -m build
+```
 
 ## License
 

--- a/examples/indexing_demo.ipynb
+++ b/examples/indexing_demo.ipynb
@@ -1,0 +1,85 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Indexing visualisation\n",
+    "\n",
+    "Visualise how an index selects elements with `show_index`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rainbow_tensor import show_index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For shape `(2, 2, 2)` the index `(0, slice(None), 1)` selects the values 1 and 3."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_index((2, 2, 2), (0, slice(None), 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Slices keep an axis. Here axis 1 is kept and the result shape is `(2, 2)`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_index((2, 2, 2), (slice(None), 1, slice(None)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A NumPy array shows its real values under the same selection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "x = np.arange(8).reshape(2, 2, 2)\n",
+    "show_index(x, (0, slice(None), 1))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/shape_demo.ipynb
+++ b/examples/shape_demo.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Shape visualisation\n",
+    "\n",
+    "Visualise the structure of a tensor shape with `show_shape`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from rainbow_tensor import show_shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_shape((3,))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_shape((2, 3))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_shape((2, 2, 2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A NumPy array works too, and its real values are shown."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "x = np.arange(8).reshape(2, 2, 2)\n",
+    "show_shape(x)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Closes #10.

Documents the package, adds example notebooks, records release notes, and verifies the build.

Changes
- rewrite the README with purpose, installation, usage, and supported and unsupported features
- add example notebooks for shape and indexing that use the public API
- add a CHANGELOG describing the first version and known limitations
- add a CI workflow that installs, lints, tests, and builds

Verified locally that python -m build produces a wheel and a source distribution.