### PR TITLE
Colour shape frames and axis numbers by axis

### DIFF
--- a/src/rainbow_tensor/layout.py
+++ b/src/rainbow_tensor/layout.py
@@ -2,17 +2,23 @@
 
 This module converts a tensor shape into 2D drawing coordinates. It knows
 nothing about SVG, so the same layout could be rendered by any backend.
+
+The tensor is drawn as nested per-axis frames. Axis 0 is the outer frame,
+each following non-leaf axis is an inner frame, and the leaf axis elements
+are placed as plain text cells inside the innermost frame.
 """
 
 from dataclasses import dataclass, field
 
 from .shape import flat_index
 
-CELL = 40
-CELL_GAP = 6
-ROW_GAP = 6
+CELL_W = 48
+CELL_H = 34
+CELL_GAP = 8
+ROW_PAD = 9
+ROW_GAP = 12
 BLOCK_PAD = 12
-BLOCK_GAP = 28
+BLOCK_GAP = 30
 PADDING = 20
 
 
@@ -25,90 +31,96 @@ class Cell:
     width: float
     height: float
     value: object
-    coord: tuple[int, ...]
+    coord: tuple
     selected: bool = False
 
 
 @dataclass
-class Block:
-    """A grouping rectangle around the rows of one axis-0 block."""
+class Frame:
+    """A grouping rectangle for one axis.
+
+    ``axis`` is the axis this frame represents, or ``None`` for a neutral
+    container that is not tied to a specific axis (used for 1D tensors).
+    ``selected`` is true when the region contains at least one selected cell.
+    """
 
     x: float
     y: float
     width: float
     height: float
-    index: int
+    axis: object
+    selected: bool = False
 
 
 @dataclass
 class Layout:
     """All drawing data for one tensor."""
 
-    cells: list[Cell] = field(default_factory=list)
-    blocks: list[Block] = field(default_factory=list)
+    cells: list = field(default_factory=list)
+    frames: list = field(default_factory=list)
     width: float = 0.0
     height: float = 0.0
 
 
-def _grid(shape: tuple[int, ...]) -> tuple[int, int, int]:
-    """Return ``(blocks, rows, cols)`` for a 1D, 2D, or 3D shape."""
-    ndim = len(shape)
-    if ndim == 1:
-        return 1, 1, shape[0]
-    if ndim == 2:
-        return 1, shape[0], shape[1]
-    return shape[0], shape[1], shape[2]
-
-
-def _coord(ndim: int, b: int, r: int, c: int) -> tuple[int, ...]:
-    """Build the real tensor coordinate for a grid position."""
-    if ndim == 1:
-        return (c,)
-    if ndim == 2:
-        return (r, c)
-    return (b, r, c)
-
-
-def build_layout(shape, selected=None, value_fn=None) -> Layout:
+def build_layout(shape, selected=None, value_fn=None):
     """Compute the layout for a tensor.
 
     ``selected`` is an iterable of coordinates to mark as selected.
     ``value_fn`` maps a coordinate to its display value. When it is ``None``
     sequential row-major values starting at 0 are used.
     """
-    selected_set = {tuple(coord) for coord in (selected or [])}
+    sel = {tuple(coord) for coord in (selected or [])}
     ndim = len(shape)
-    blocks, rows, cols = _grid(shape)
+    cols = shape[-1]
 
-    block_w = cols * CELL + (cols - 1) * CELL_GAP + 2 * BLOCK_PAD
-    block_h = rows * CELL + (rows - 1) * ROW_GAP + 2 * BLOCK_PAD
+    row_w = cols * CELL_W + (cols - 1) * CELL_GAP + 2 * ROW_PAD
+    row_h = CELL_H + 2 * ROW_PAD
 
     layout = Layout()
+
+    def place_cells(rx, ry, prefix):
+        for c in range(cols):
+            x = rx + ROW_PAD + c * (CELL_W + CELL_GAP)
+            coord = prefix + (c,)
+            value = value_fn(coord) if value_fn is not None else flat_index(coord, shape)
+            layout.cells.append(
+                Cell(x, ry + ROW_PAD, CELL_W, CELL_H, value, coord, coord in sel)
+            )
+
+    if ndim == 1:
+        rx, ry = PADDING, PADDING
+        layout.frames.append(Frame(rx, ry, row_w, row_h, axis=None, selected=bool(sel)))
+        place_cells(rx, ry, ())
+        layout.width = PADDING * 2 + row_w
+        layout.height = PADDING * 2 + row_h
+        return layout
+
+    if ndim == 2:
+        rows = shape[0]
+        for r in range(rows):
+            rx = PADDING
+            ry = PADDING + r * (row_h + ROW_GAP)
+            row_sel = any(co[0] == r for co in sel)
+            layout.frames.append(Frame(rx, ry, row_w, row_h, axis=0, selected=row_sel))
+            place_cells(rx, ry, (r,))
+        layout.width = PADDING * 2 + row_w
+        layout.height = PADDING * 2 + rows * row_h + (rows - 1) * ROW_GAP
+        return layout
+
+    blocks, rows, _ = shape
+    block_w = row_w + 2 * BLOCK_PAD
+    block_h = rows * row_h + (rows - 1) * ROW_GAP + 2 * BLOCK_PAD
     for b in range(blocks):
         bx = PADDING + b * (block_w + BLOCK_GAP)
         by = PADDING
-        layout.blocks.append(Block(bx, by, block_w, block_h, b))
+        block_sel = any(co[0] == b for co in sel)
+        layout.frames.append(Frame(bx, by, block_w, block_h, axis=0, selected=block_sel))
         for r in range(rows):
-            for c in range(cols):
-                x = bx + BLOCK_PAD + c * (CELL + CELL_GAP)
-                y = by + BLOCK_PAD + r * (CELL + ROW_GAP)
-                coord = _coord(ndim, b, r, c)
-                if value_fn is not None:
-                    value = value_fn(coord)
-                else:
-                    value = flat_index(coord, shape)
-                layout.cells.append(
-                    Cell(
-                        x=x,
-                        y=y,
-                        width=CELL,
-                        height=CELL,
-                        value=value,
-                        coord=coord,
-                        selected=coord in selected_set,
-                    )
-                )
-
+            rx = bx + BLOCK_PAD
+            ry = by + BLOCK_PAD + r * (row_h + ROW_GAP)
+            row_sel = any(co[0] == b and co[1] == r for co in sel)
+            layout.frames.append(Frame(rx, ry, row_w, row_h, axis=1, selected=row_sel))
+            place_cells(rx, ry, (b, r))
     layout.width = PADDING * 2 + blocks * block_w + (blocks - 1) * BLOCK_GAP
     layout.height = PADDING * 2 + block_h
     return layout

--- a/src/rainbow_tensor/notebook.py
+++ b/src/rainbow_tensor/notebook.py
@@ -12,8 +12,12 @@ from .indexing import (
     selected_coordinates,
     validate_index,
 )
-from .render_svg import render_svg
-from .shape import extract_shape, format_shape_label
+from .render_svg import (
+    AXIS_FRAME_COLORS,
+    NEUTRAL_COLOR,
+    render_svg,
+)
+from .shape import extract_shape
 
 
 class TensorVisual:
@@ -60,6 +64,26 @@ def _value_fn_for(obj):
     return value_fn
 
 
+def _shape_label_parts(shape):
+    """Build coloured label parts for a shape.
+
+    Each dimension is coloured to match its frame. Frame axes use their axis
+    colour and the leaf axis stays neutral, since it has no frame.
+    """
+    ndim = len(shape)
+    parts = [("Shape (", NEUTRAL_COLOR)]
+    for axis, dim in enumerate(shape):
+        if axis < ndim - 1:
+            color = AXIS_FRAME_COLORS.get(axis, NEUTRAL_COLOR)
+        else:
+            color = NEUTRAL_COLOR
+        parts.append((str(dim), color))
+        if axis < ndim - 1:
+            parts.append((", ", NEUTRAL_COLOR))
+    parts.append((")", NEUTRAL_COLOR))
+    return parts
+
+
 def _display(visual):
     """Display a visual in IPython when available, otherwise do nothing."""
     try:
@@ -79,8 +103,8 @@ def show_shape(shape):
     """
     normalized = extract_shape(shape)
     value_fn = _value_fn_for(shape)
-    label = f"Shape {format_shape_label(normalized)}"
-    svg = render_svg(normalized, value_fn=value_fn, label=label)
+    label_parts = _shape_label_parts(normalized)
+    svg = render_svg(normalized, value_fn=value_fn, label_parts=label_parts)
     visual = TensorVisual(svg, normalized)
     _display(visual)
     return visual

--- a/src/rainbow_tensor/render_svg.py
+++ b/src/rainbow_tensor/render_svg.py
@@ -1,24 +1,23 @@
 """SVG rendering.
 
 This module turns a :class:`~rainbow_tensor.layout.Layout` into an SVG
-string. It draws the tensor blocks, cells, values, and a label. Selected
-cells are highlighted and, when a selection exists, the unselected cells are
-de-emphasised but still readable. An optional explanation is drawn below.
+string. Each axis has its own colour. Axis 0 frames are red and axis 1
+frames are orange. The leaf axis elements are plain text. Selected elements
+are drawn green and, in an index view, only the selected frames keep their
+axis colour while the rest are drawn in a neutral dark tone.
 """
 
 from .layout import build_layout
 
-CELL_FILL = "#ffffff"
-CELL_STROKE = "#94a3b8"
-BLOCK_STROKE = "#cbd5e1"
-HIGHLIGHT_FILL = "#fde68a"
-HIGHLIGHT_STROKE = "#d97706"
-TEXT_COLOR = "#0f172a"
+AXIS_FRAME_COLORS = {0: "#dc2626", 1: "#f97316"}
+SELECT_VALUE_COLOR = "#16a34a"
+NEUTRAL_COLOR = "#111827"
+TEXT_COLOR = "#111827"
 LABEL_COLOR = "#334155"
-DIM_OPACITY = 0.3
 
-LABEL_HEIGHT = 28
+LABEL_HEIGHT = 30
 LINE_HEIGHT = 20
+FRAME_WIDTH = 3
 FONT_FAMILY = "ui-monospace, Menlo, Consolas, monospace"
 
 
@@ -45,12 +44,44 @@ def svg_document(content, width, height):
     )
 
 
-def render_svg(shape, selected=None, value_fn=None, label="", explanation=None):
+def _frame_color(frame, has_selection):
+    """Pick the stroke colour for a frame.
+
+    In a shape view every frame uses its axis colour. In an index view only
+    selected frames keep their axis colour, the rest are neutral.
+    """
+    axis_color = AXIS_FRAME_COLORS.get(frame.axis, NEUTRAL_COLOR)
+    if not has_selection:
+        return axis_color
+    return axis_color if frame.selected else NEUTRAL_COLOR
+
+
+def _cell_color(cell, has_selection):
+    """Pick the text colour for a cell value."""
+    if has_selection and cell.selected:
+        return SELECT_VALUE_COLOR
+    return TEXT_COLOR
+
+
+def _label_element(x, y, parts):
+    """Build a label text element from coloured parts."""
+    spans = "".join(
+        f'<tspan fill="{escape(color)}">{escape(text)}</tspan>' for text, color in parts
+    )
+    return (
+        f'<text x="{x:.0f}" y="{y:.0f}" font-size="16" font-weight="600">{spans}</text>'
+    )
+
+
+def render_svg(
+    shape, selected=None, value_fn=None, label="", label_parts=None, explanation=None
+):
     """Render a tensor as an SVG string.
 
     ``selected`` is an iterable of selected coordinates. ``value_fn`` maps a
-    coordinate to its display value. ``label`` is drawn under the tensor and
-    ``explanation`` is an optional list of lines drawn below the label.
+    coordinate to its display value. ``label`` is a plain label string while
+    ``label_parts`` is an optional list of ``(text, colour)`` pairs for a
+    coloured label. ``explanation`` is an optional list of lines drawn below.
     """
     explanation = explanation or []
     selected_list = list(selected or [])
@@ -59,49 +90,32 @@ def render_svg(shape, selected=None, value_fn=None, label="", explanation=None):
 
     parts = []
 
-    for block in layout.blocks:
-        if has_selection:
-            block_selected = any(
-                cell.selected for cell in layout.cells if cell.coord[0] == block.index
-            )
-            opacity = 1.0 if block_selected else DIM_OPACITY
-        else:
-            opacity = 1.0
+    for frame in layout.frames:
+        color = _frame_color(frame, has_selection)
         parts.append(
-            f'<rect x="{block.x:.0f}" y="{block.y:.0f}" '
-            f'width="{block.width:.0f}" height="{block.height:.0f}" '
-            f'rx="8" fill="none" stroke="{BLOCK_STROKE}" stroke-width="1.5" '
-            f'opacity="{opacity:.2f}"/>'
+            f'<rect x="{frame.x:.0f}" y="{frame.y:.0f}" '
+            f'width="{frame.width:.0f}" height="{frame.height:.0f}" '
+            f'rx="6" fill="none" stroke="{color}" stroke-width="{FRAME_WIDTH}"/>'
         )
 
     for cell in layout.cells:
-        if cell.selected:
-            fill = HIGHLIGHT_FILL
-            stroke = HIGHLIGHT_STROKE
-            opacity = 1.0
-            weight = "700"
-        else:
-            fill = CELL_FILL
-            stroke = CELL_STROKE
-            opacity = DIM_OPACITY if has_selection else 1.0
-            weight = "400"
+        color = _cell_color(cell, has_selection)
+        weight = "700" if (has_selection and cell.selected) else "400"
         cx = cell.x + cell.width / 2
         cy = cell.y + cell.height / 2
         parts.append(
-            f'<g opacity="{opacity:.2f}">'
-            f'<rect x="{cell.x:.0f}" y="{cell.y:.0f}" '
-            f'width="{cell.width:.0f}" height="{cell.height:.0f}" '
-            f'rx="6" fill="{fill}" stroke="{stroke}" stroke-width="1.5"/>'
             f'<text x="{cx:.0f}" y="{cy:.0f}" text-anchor="middle" '
             f'dominant-baseline="central" font-size="15" font-weight="{weight}" '
-            f'fill="{TEXT_COLOR}">{escape(cell.value)}</text>'
-            f"</g>"
+            f'fill="{color}">{escape(cell.value)}</text>'
         )
 
     width = layout.width
     y = layout.height + LABEL_HEIGHT
 
-    if label:
+    if label_parts:
+        parts.append(_label_element(20, y, label_parts))
+        y += LINE_HEIGHT
+    elif label:
         parts.append(
             f'<text x="20" y="{y:.0f}" font-size="16" font-weight="600" '
             f'fill="{LABEL_COLOR}">{escape(label)}</text>'

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -6,16 +6,23 @@ from rainbow_tensor.layout import build_layout
 def test_one_dimensional_layout_cell_count():
     layout = build_layout((3,))
     assert len(layout.cells) == 3
+    assert len(layout.frames) == 1
+    assert layout.frames[0].axis is None
 
 
 def test_two_dimensional_layout_cell_count():
     layout = build_layout((2, 3))
     assert len(layout.cells) == 6
+    assert len(layout.frames) == 2
+    assert all(frame.axis == 0 for frame in layout.frames)
 
 
 def test_three_dimensional_layout_structure():
     layout = build_layout((2, 2, 2))
-    assert len(layout.blocks) == 2
+    block_frames = [f for f in layout.frames if f.axis == 0]
+    row_frames = [f for f in layout.frames if f.axis == 1]
+    assert len(block_frames) == 2
+    assert len(row_frames) == 4
     assert len(layout.cells) == 8
     by_value = {cell.value: cell.coord for cell in layout.cells}
     assert by_value[0] == (0, 0, 0)
@@ -42,7 +49,10 @@ def test_value_fn_overrides_generated_values():
     assert values == [0, 10, 20]
 
 
-def test_selected_coordinates_are_marked():
-    layout = build_layout((2, 2, 2), selected=[(0, 0, 1)])
-    selected = [cell.coord for cell in layout.cells if cell.selected]
-    assert selected == [(0, 0, 1)]
+def test_selected_block_and_row_frames_are_marked():
+    layout = build_layout((2, 2, 2), selected=[(0, 0, 1), (0, 1, 1)])
+    block_frames = [f for f in layout.frames if f.axis == 0]
+    assert block_frames[0].selected is True
+    assert block_frames[1].selected is False
+    selected_cells = [cell.coord for cell in layout.cells if cell.selected]
+    assert selected_cells == [(0, 0, 1), (0, 1, 1)]

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -25,7 +25,15 @@ def test_show_shape_returns_visual_with_svg():
 def test_show_shape_repr_svg_matches_svg():
     visual = show_shape((3,))
     assert visual._repr_svg_() == visual.svg
-    assert "Shape (3)" in visual.svg
+    assert "Shape (" in visual.svg
+
+
+def test_show_shape_label_colours_frame_axes():
+    visual = show_shape((2, 2, 2))
+    # axis 0 red and axis 1 orange appear both as frames and as label numbers
+    assert "#dc2626" in visual.svg
+    assert "#f97316" in visual.svg
+    assert "<tspan" in visual.svg
 
 
 def test_show_shape_uses_array_values():

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -43,7 +43,7 @@ def test_show_index_computes_selection_and_result_shape():
 
 def test_show_index_highlights_selected_values():
     visual = show_index((2, 2, 2), (0, slice(None), 1))
-    assert "#fde68a" in visual.svg
+    assert "#16a34a" in visual.svg
     assert visual.svg.startswith("<svg")
 
 

--- a/tests/test_render_svg.py
+++ b/tests/test_render_svg.py
@@ -1,6 +1,12 @@
 """Tests for SVG rendering."""
 
-from rainbow_tensor.render_svg import escape, render_svg, svg_document
+from rainbow_tensor.render_svg import (
+    AXIS_FRAME_COLORS,
+    SELECT_VALUE_COLOR,
+    escape,
+    render_svg,
+    svg_document,
+)
 
 
 def test_escape_replaces_markup_characters():
@@ -15,38 +21,43 @@ def test_svg_document_is_well_formed():
 
 
 def test_render_svg_starts_with_svg_tag():
-    svg = render_svg((3,), label="Shape (3)")
+    svg = render_svg((3,))
     assert svg.startswith("<svg")
 
 
-def test_render_svg_includes_label_and_values():
-    svg = render_svg((2, 2, 2), label="Shape (2, 2, 2)")
-    assert "Shape (2, 2, 2)" in svg
+def test_render_svg_includes_values():
+    svg = render_svg((2, 2, 2))
     assert ">7<" in svg
 
 
-def test_render_svg_draws_one_rect_per_cell_plus_blocks():
+def test_shape_view_colours_frames_by_axis():
     svg = render_svg((2, 2, 2))
-    assert svg.count("<rect") == 8 + 2
+    assert AXIS_FRAME_COLORS[0] in svg
+    assert AXIS_FRAME_COLORS[1] in svg
 
 
-def test_render_svg_highlights_selected_cells():
-    selected = [(0, 0, 1), (0, 1, 1)]
-    svg = render_svg((2, 2, 2), selected=selected)
-    assert "#fde68a" in svg
+def test_three_dimensional_shape_draws_six_frames():
+    # two axis-0 block frames plus four axis-1 row frames
+    svg = render_svg((2, 2, 2))
+    assert svg.count("<rect") == 6
 
 
-def test_render_svg_dims_unselected_cells_when_selection_exists():
-    svg = render_svg((2, 2, 2), selected=[(0, 0, 1)])
-    assert 'opacity="0.30"' in svg
+def test_index_view_highlights_selected_values_green():
+    svg = render_svg((2, 2, 2), selected=[(0, 0, 1), (0, 1, 1)])
+    assert SELECT_VALUE_COLOR in svg
+
+
+def test_label_parts_render_coloured_tspans():
+    svg = render_svg((3,), label_parts=[("Shape (", "#000000"), ("3", "#dc2626")])
+    assert "<tspan" in svg
+    assert 'fill="#dc2626"' in svg
 
 
 def test_render_svg_includes_explanation_lines():
     svg = render_svg(
         (2, 2, 2),
         selected=[(0, 0, 1), (0, 1, 1)],
-        label="Index [0, :, 1]",
+        label="Index (0, :, 1)",
         explanation=["Result shape: (2,)"],
     )
     assert "Result shape: (2,)" in svg
-    assert "Index [0, :, 1]" in svg


### PR DESCRIPTION
Closes #12.

Redesigns the visualisation so each axis has its own colour.

Changes
- layout now produces nested per-axis frames with the leaf axis as plain text cells
- axis 0 frames are red and axis 1 frames are orange
- the shape label numbers are coloured to match their frames, the leaf number stays neutral
- the renderer supports coloured label parts through tspans
- tests updated for the new frame structure and colours