### PR TITLE
Colour index label tokens to match selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 0.2.0
+
+### Changed
+
+- Redesigned the visualisation so each axis has its own colour, with axis 0 frames red, axis 1 frames orange, and selected leaf values green
+- The shape label numbers and the index label tokens are now coloured to match the frames and the selected values
+- In an index view the unselected frames and values are drawn in a neutral dark tone instead of being faded
+
 ## 0.1.0
 
 First version.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ rainbow-tensor is made for people who are learning how a tensor is structured an
 - Works with shape tuples and with array-like objects that expose a `.shape` attribute, such as NumPy arrays
 - No tensor library is imported by the core, so the package stays lightweight
 
+## Colour scheme
+
+Each axis has its own colour so the structure and a selection are easy to read.
+
+- Axis 0 is the outer frame, drawn red
+- Axis 1 is the inner row frame, drawn orange
+- The leaf axis elements are plain text, and a selected element is drawn green
+- The numbers in the shape label and the tokens in the index label are coloured to match
+
+In an index view only the selected frames keep their axis colour. The rest of the tensor is drawn in a neutral dark tone so the selected path stands out.
+
 ## Installation
 
 Install from source for development.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rainbow-tensor"
-version = "0.1.0"
+version = "0.2.0"
 description = "Visualise tensor shape, indexing, and slicing as SVG in Jupyter notebooks"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/rainbow_tensor/__init__.py
+++ b/src/rainbow_tensor/__init__.py
@@ -14,5 +14,5 @@ Public API:
 
 from .notebook import show_index, show_shape
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["show_shape", "show_index", "__version__"]

--- a/src/rainbow_tensor/notebook.py
+++ b/src/rainbow_tensor/notebook.py
@@ -7,7 +7,7 @@ inspectable in plain Python, so the package is testable outside a notebook.
 
 from .indexing import (
     explain_index,
-    format_index,
+    format_slice,
     result_shape,
     selected_coordinates,
     validate_index,
@@ -15,6 +15,7 @@ from .indexing import (
 from .render_svg import (
     AXIS_FRAME_COLORS,
     NEUTRAL_COLOR,
+    SELECT_VALUE_COLOR,
     render_svg,
 )
 from .shape import extract_shape
@@ -84,6 +85,28 @@ def _shape_label_parts(shape):
     return parts
 
 
+def _index_label_parts(index):
+    """Build coloured label parts for an index.
+
+    Each token is coloured to match its axis. Frame axes use their axis
+    colour and the leaf axis uses the selected value colour, so the label
+    mirrors the colours drawn on the tensor.
+    """
+    ndim = len(index)
+    parts = [("Index (", NEUTRAL_COLOR)]
+    for axis, entry in enumerate(index):
+        token = format_slice(entry) if isinstance(entry, slice) else str(entry)
+        if axis < ndim - 1:
+            color = AXIS_FRAME_COLORS.get(axis, NEUTRAL_COLOR)
+        else:
+            color = SELECT_VALUE_COLOR
+        parts.append((token, color))
+        if axis < ndim - 1:
+            parts.append((", ", NEUTRAL_COLOR))
+    parts.append((")", NEUTRAL_COLOR))
+    return parts
+
+
 def _display(visual):
     """Display a visual in IPython when available, otherwise do nothing."""
     try:
@@ -125,12 +148,12 @@ def show_index(tensor_or_shape, index):
     result = result_shape(normalized, index)
     explanation = explain_index(normalized, index)
     value_fn = _value_fn_for(tensor_or_shape)
-    label = f"Index [{format_index(index)}]"
+    label_parts = _index_label_parts(index)
     svg = render_svg(
         normalized,
         selected=selected,
         value_fn=value_fn,
-        label=label,
+        label_parts=label_parts,
         explanation=explanation,
     )
     visual = TensorVisual(

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -55,6 +55,14 @@ def test_show_index_highlights_selected_values():
     assert visual.svg.startswith("<svg")
 
 
+def test_show_index_label_colours_tokens_by_axis():
+    visual = show_index((2, 2, 2), (0, slice(None), 1))
+    # red axis 0 token, orange axis 1 token, green leaf token, all as tspans
+    assert '<tspan fill="#dc2626">0</tspan>' in visual.svg
+    assert '<tspan fill="#f97316">:</tspan>' in visual.svg
+    assert '<tspan fill="#16a34a">1</tspan>' in visual.svg
+
+
 def test_show_index_uses_array_values():
     values = {}
     for i in range(2):


### PR DESCRIPTION
Closes #14.

Colours the index label tokens to match the frames and the selected values.

Changes
- the index label is built from coloured tokens, red for axis 0, orange for axis 1, green for the leaf
- show_index now passes the coloured label parts to the renderer
- README documents the per-axis colour scheme
- CHANGELOG records the change and the version is bumped to 0.2.0

For show_index((2, 2, 2), (0, slice(None), 1)) the label shows a red 0, an orange :, and a green 1, matching the red block frame, orange row frames, and green values 1 and 3.