### PR TITLE
Fix duplicated notebook output and truncated explanation text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.2.1
+
+### Fixed
+
+- show_shape and show_index no longer render twice in a notebook cell. The result renders once through _repr_svg_ and is still returned for inspection
+- The SVG width now grows to fit the label and explanation lines, so longer text is no longer clipped at the edge of the frame
+
 ## 0.2.0
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "rainbow-tensor"
-version = "0.2.0"
+version = "0.2.1"
 description = "Visualise tensor shape, indexing, and slicing as SVG in Jupyter notebooks"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/rainbow_tensor/__init__.py
+++ b/src/rainbow_tensor/__init__.py
@@ -14,5 +14,5 @@ Public API:
 
 from .notebook import show_index, show_shape
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = ["show_shape", "show_index", "__version__"]

--- a/src/rainbow_tensor/notebook.py
+++ b/src/rainbow_tensor/notebook.py
@@ -107,30 +107,19 @@ def _index_label_parts(index):
     return parts
 
 
-def _display(visual):
-    """Display a visual in IPython when available, otherwise do nothing."""
-    try:
-        from IPython.display import display
-    except Exception:
-        return
-    display(visual)
-
-
 def show_shape(shape):
     """Visualise the structure of a tensor shape.
 
     ``shape`` may be a tuple such as ``(2, 2, 2)`` or an array-like object
-    with a ``.shape`` attribute such as a NumPy array. The tensor is rendered
-    as SVG and displayed in a notebook. The returned :class:`TensorVisual`
-    also exposes the SVG string.
+    with a ``.shape`` attribute such as a NumPy array. The returned
+    :class:`TensorVisual` renders as SVG in a notebook through ``_repr_svg_``
+    and also exposes the SVG string for inspection and testing.
     """
     normalized = extract_shape(shape)
     value_fn = _value_fn_for(shape)
     label_parts = _shape_label_parts(normalized)
     svg = render_svg(normalized, value_fn=value_fn, label_parts=label_parts)
-    visual = TensorVisual(svg, normalized)
-    _display(visual)
-    return visual
+    return TensorVisual(svg, normalized)
 
 
 def show_index(tensor_or_shape, index):
@@ -140,7 +129,9 @@ def show_index(tensor_or_shape, index):
     ``.shape`` attribute. ``index`` must be a tuple of integers and slices
     whose length matches the tensor rank. Selected elements are highlighted,
     unselected elements stay visible but de-emphasised, and an explanation of
-    the result shape is drawn below the tensor.
+    the result shape is drawn below the tensor. The returned
+    :class:`TensorVisual` renders as SVG in a notebook through ``_repr_svg_``
+    and also exposes the SVG string for inspection and testing.
     """
     normalized = extract_shape(tensor_or_shape)
     validate_index(index, normalized)
@@ -156,8 +147,6 @@ def show_index(tensor_or_shape, index):
         label_parts=label_parts,
         explanation=explanation,
     )
-    visual = TensorVisual(
+    return TensorVisual(
         svg, normalized, selected=selected, result=result, explanation=explanation
     )
-    _display(visual)
-    return visual

--- a/src/rainbow_tensor/render_svg.py
+++ b/src/rainbow_tensor/render_svg.py
@@ -18,6 +18,11 @@ LABEL_COLOR = "#334155"
 LABEL_HEIGHT = 30
 LINE_HEIGHT = 20
 FRAME_WIDTH = 3
+TEXT_MARGIN = 20
+LABEL_FONT_SIZE = 16
+EXPLANATION_FONT_SIZE = 13
+# Approximate width of one monospace character relative to the font size.
+CHAR_WIDTH_RATIO = 0.62
 FONT_FAMILY = "ui-monospace, Menlo, Consolas, monospace"
 
 
@@ -61,6 +66,19 @@ def _cell_color(cell, has_selection):
     if has_selection and cell.selected:
         return SELECT_VALUE_COLOR
     return TEXT_COLOR
+
+
+def _text_width(char_count, font_size):
+    """Estimate the rendered width of a monospace string."""
+    return char_count * font_size * CHAR_WIDTH_RATIO
+
+
+def _text_block_width(label_len, explanation):
+    """Estimate the width needed so the label and explanation are not clipped."""
+    widest = _text_width(label_len, LABEL_FONT_SIZE)
+    for line in explanation:
+        widest = max(widest, _text_width(len(line), EXPLANATION_FONT_SIZE))
+    return 2 * TEXT_MARGIN + widest
 
 
 def _label_element(x, y, parts):
@@ -109,7 +127,12 @@ def render_svg(
             f'fill="{color}">{escape(cell.value)}</text>'
         )
 
-    width = layout.width
+    if label_parts:
+        label_len = sum(len(text) for text, _ in label_parts)
+    else:
+        label_len = len(label)
+    text_width = _text_block_width(label_len, explanation)
+    width = max(layout.width, text_width)
     y = layout.height + LABEL_HEIGHT
 
     if label_parts:

--- a/tests/test_notebook.py
+++ b/tests/test_notebook.py
@@ -28,6 +28,21 @@ def test_show_shape_repr_svg_matches_svg():
     assert "Shape (" in visual.svg
 
 
+def test_show_functions_do_not_call_display(monkeypatch):
+    # The result renders once through _repr_svg_, so the functions must not
+    # call display themselves, otherwise a notebook cell shows it twice.
+    import sys
+
+    calls = []
+    fake_module = type(sys)("IPython.display")
+    fake_module.display = lambda *args, **kwargs: calls.append(args)
+    monkeypatch.setitem(sys.modules, "IPython.display", fake_module)
+
+    show_shape((2, 2, 2))
+    show_index((2, 2, 2), (0, slice(None), 1))
+    assert calls == []
+
+
 def test_show_shape_label_colours_frame_axes():
     visual = show_shape((2, 2, 2))
     # axis 0 red and axis 1 orange appear both as frames and as label numbers

--- a/tests/test_render_svg.py
+++ b/tests/test_render_svg.py
@@ -53,6 +53,17 @@ def test_label_parts_render_coloured_tspans():
     assert 'fill="#dc2626"' in svg
 
 
+def test_width_grows_to_fit_long_explanation():
+    import re
+
+    long_line = "Axis 0 is removed because integer index 0 is used and it is long"
+    svg = render_svg((2,), label="Index (0,)", explanation=[long_line])
+    width = int(re.search(r'width="(\d+)"', svg).group(1))
+    # the explanation is far wider than the tiny 1D tensor, so the canvas must
+    # have grown well beyond the default tensor width to avoid clipping
+    assert width > len(long_line) * 7
+
+
 def test_render_svg_includes_explanation_lines():
     svg = render_svg(
         (2, 2, 2),


### PR DESCRIPTION
Closes #16.

Fixes two notebook output bugs.

Changes
- show_shape and show_index no longer call display themselves. The returned TensorVisual renders once through _repr_svg_ and is still returned for inspection, so a cell shows the visualisation only once
- the SVG width now grows to fit the label and explanation lines, so longer text is no longer clipped
- added regression tests for both fixes and bumped the version to 0.2.1