### PR TITLE
Update README install and adopt rt import convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ rainbow-tensor is made for people who are learning how a tensor is structured an
 
 ## Examples
 
-`show_shape((2, 2, 2))`
+`rt.show_shape((2, 2, 2))`
 
 ![Shape (2, 2, 2)](examples/images/shape_2x2x2.svg)
 
-`show_index((2, 2, 2), (0, slice(None), 1))`
+`rt.show_index((2, 2, 2), (0, slice(None), 1))`
 
 ![Index (0, :, 1)](examples/images/index_0_all_1.svg)
 
@@ -37,6 +37,12 @@ In an index view only the selected frames keep their axis colour. The rest of th
 
 ## Installation
 
+Install from PyPI.
+
+```bash
+pip install rainbow-tensor
+```
+
 Install from source for development.
 
 ```bash
@@ -51,24 +57,28 @@ Install with the development tools (pytest, ruff, build).
 pip install -e ".[dev]"
 ```
 
+The distribution name is `rainbow-tensor` and the import name is `rainbow_tensor`.
+
 ## Usage
 
 Run the examples in a Jupyter notebook or an IPython shell so the SVG is displayed.
 
+The convention is to import the package as `rt`.
+
 Visualise a shape.
 
 ```python
-from rainbow_tensor import show_shape
+import rainbow_tensor as rt
 
-show_shape((2, 2, 2))
+rt.show_shape((2, 2, 2))
 ```
 
 Visualise how an index selects elements.
 
 ```python
-from rainbow_tensor import show_index
+import rainbow_tensor as rt
 
-show_index((2, 2, 2), (0, slice(None), 1))
+rt.show_index((2, 2, 2), (0, slice(None), 1))
 ```
 
 For the shape `(2, 2, 2)` the index `(0, slice(None), 1)` selects the values `1` and `3`, the selected coordinates are `(0, 0, 1)` and `(0, 1, 1)`, and the result shape is `(2,)`.
@@ -77,11 +87,11 @@ Use a real NumPy array to display its actual values.
 
 ```python
 import numpy as np
-from rainbow_tensor import show_shape, show_index
+import rainbow_tensor as rt
 
 x = np.arange(8).reshape(2, 2, 2)
-show_shape(x)
-show_index(x, (0, slice(None), 1))
+rt.show_shape(x)
+rt.show_index(x, (0, slice(None), 1))
 ```
 
 Each function returns a small result object. Its `svg` attribute holds the SVG string, so the package can be inspected and tested outside a notebook.

--- a/examples/indexing_demo.ipynb
+++ b/examples/indexing_demo.ipynb
@@ -16,15 +16,15 @@
    "id": "0436c0fc",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:19.644710Z",
-     "iopub.status.busy": "2026-06-16T02:10:19.644710Z",
-     "iopub.status.idle": "2026-06-16T02:10:19.650895Z",
-     "shell.execute_reply": "2026-06-16T02:10:19.650895Z"
+     "iopub.execute_input": "2026-06-16T02:12:51.793134Z",
+     "iopub.status.busy": "2026-06-16T02:12:51.793134Z",
+     "iopub.status.idle": "2026-06-16T02:12:51.799226Z",
+     "shell.execute_reply": "2026-06-16T02:12:51.799226Z"
     }
    },
    "outputs": [],
    "source": [
-    "from rainbow_tensor import show_index"
+    "import rainbow_tensor as rt"
    ]
   },
   {
@@ -41,10 +41,10 @@
    "id": "e3a859ec",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:19.652462Z",
-     "iopub.status.busy": "2026-06-16T02:10:19.652462Z",
-     "iopub.status.idle": "2026-06-16T02:10:19.655991Z",
-     "shell.execute_reply": "2026-06-16T02:10:19.655991Z"
+     "iopub.execute_input": "2026-06-16T02:12:51.800235Z",
+     "iopub.status.busy": "2026-06-16T02:12:51.800235Z",
+     "iopub.status.idle": "2026-06-16T02:12:51.804276Z",
+     "shell.execute_reply": "2026-06-16T02:12:51.804276Z"
     }
    },
    "outputs": [
@@ -54,7 +54,7 @@
        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"443\" height=\"342\" viewBox=\"0 0 443 342\" font-family=\"ui-monospace, Menlo, Consolas, monospace\"><rect x=\"20\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"32\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"32\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"196\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><rect x=\"208\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><rect x=\"208\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><text x=\"65\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">0</text><text x=\"121\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"700\" fill=\"#16a34a\">1</text><text x=\"65\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">2</text><text x=\"121\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"700\" fill=\"#16a34a\">3</text><text x=\"241\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">4</text><text x=\"297\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">5</text><text x=\"241\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">6</text><text x=\"297\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">7</text><text x=\"20\" y=\"210\" font-size=\"16\" font-weight=\"600\"><tspan fill=\"#111827\">Index (</tspan><tspan fill=\"#dc2626\">0</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#f97316\">:</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#16a34a\">1</tspan><tspan fill=\"#111827\">)</tspan></text><text x=\"20\" y=\"246\" font-size=\"13\" fill=\"#334155\">Original shape: (2, 2, 2)</text><text x=\"20\" y=\"262\" font-size=\"13\" fill=\"#334155\">Index: 0, :, 1</text><text x=\"20\" y=\"278\" font-size=\"13\" fill=\"#334155\">Result shape: (2,)</text><text x=\"20\" y=\"294\" font-size=\"13\" fill=\"#334155\">Axis 0 is removed because integer index 0 is used.</text><text x=\"20\" y=\"310\" font-size=\"13\" fill=\"#334155\">Axis 1 is kept because slice : is used.</text><text x=\"20\" y=\"326\" font-size=\"13\" fill=\"#334155\">Axis 2 is removed because integer index 1 is used.</text></svg>"
       ],
       "text/plain": [
-       "<rainbow_tensor.notebook.TensorVisual at 0x1abb686aff0>"
+       "<rainbow_tensor.notebook.TensorVisual at 0x23009be3b00>"
       ]
      },
      "execution_count": 2,
@@ -63,7 +63,7 @@
     }
    ],
    "source": [
-    "show_index((2, 2, 2), (0, slice(None), 1))"
+    "rt.show_index((2, 2, 2), (0, slice(None), 1))"
    ]
   },
   {
@@ -80,10 +80,10 @@
    "id": "c98f3a5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:19.657016Z",
-     "iopub.status.busy": "2026-06-16T02:10:19.657016Z",
-     "iopub.status.idle": "2026-06-16T02:10:19.660252Z",
-     "shell.execute_reply": "2026-06-16T02:10:19.660252Z"
+     "iopub.execute_input": "2026-06-16T02:12:51.805283Z",
+     "iopub.status.busy": "2026-06-16T02:12:51.805283Z",
+     "iopub.status.idle": "2026-06-16T02:12:51.808233Z",
+     "shell.execute_reply": "2026-06-16T02:12:51.808233Z"
     }
    },
    "outputs": [
@@ -93,7 +93,7 @@
        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"443\" height=\"342\" viewBox=\"0 0 443 342\" font-family=\"ui-monospace, Menlo, Consolas, monospace\"><rect x=\"20\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"32\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><rect x=\"32\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"196\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"208\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><rect x=\"208\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><text x=\"65\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">0</text><text x=\"121\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">1</text><text x=\"65\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"700\" fill=\"#16a34a\">2</text><text x=\"121\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"700\" fill=\"#16a34a\">3</text><text x=\"241\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">4</text><text x=\"297\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">5</text><text x=\"241\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"700\" fill=\"#16a34a\">6</text><text x=\"297\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"700\" fill=\"#16a34a\">7</text><text x=\"20\" y=\"210\" font-size=\"16\" font-weight=\"600\"><tspan fill=\"#111827\">Index (</tspan><tspan fill=\"#dc2626\">:</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#f97316\">1</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#16a34a\">:</tspan><tspan fill=\"#111827\">)</tspan></text><text x=\"20\" y=\"246\" font-size=\"13\" fill=\"#334155\">Original shape: (2, 2, 2)</text><text x=\"20\" y=\"262\" font-size=\"13\" fill=\"#334155\">Index: :, 1, :</text><text x=\"20\" y=\"278\" font-size=\"13\" fill=\"#334155\">Result shape: (2, 2)</text><text x=\"20\" y=\"294\" font-size=\"13\" fill=\"#334155\">Axis 0 is kept because slice : is used.</text><text x=\"20\" y=\"310\" font-size=\"13\" fill=\"#334155\">Axis 1 is removed because integer index 1 is used.</text><text x=\"20\" y=\"326\" font-size=\"13\" fill=\"#334155\">Axis 2 is kept because slice : is used.</text></svg>"
       ],
       "text/plain": [
-       "<rainbow_tensor.notebook.TensorVisual at 0x1abb68a2de0>"
+       "<rainbow_tensor.notebook.TensorVisual at 0x2300727aff0>"
       ]
      },
      "execution_count": 3,
@@ -102,7 +102,7 @@
     }
    ],
    "source": [
-    "show_index((2, 2, 2), (slice(None), 1, slice(None)))"
+    "rt.show_index((2, 2, 2), (slice(None), 1, slice(None)))"
    ]
   },
   {
@@ -119,10 +119,10 @@
    "id": "dca032cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:19.661774Z",
-     "iopub.status.busy": "2026-06-16T02:10:19.660761Z",
-     "iopub.status.idle": "2026-06-16T02:10:19.715717Z",
-     "shell.execute_reply": "2026-06-16T02:10:19.715717Z"
+     "iopub.execute_input": "2026-06-16T02:12:51.808739Z",
+     "iopub.status.busy": "2026-06-16T02:12:51.808739Z",
+     "iopub.status.idle": "2026-06-16T02:12:51.859452Z",
+     "shell.execute_reply": "2026-06-16T02:12:51.858942Z"
     }
    },
    "outputs": [
@@ -132,7 +132,7 @@
        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"443\" height=\"342\" viewBox=\"0 0 443 342\" font-family=\"ui-monospace, Menlo, Consolas, monospace\"><rect x=\"20\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"32\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"32\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"196\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><rect x=\"208\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><rect x=\"208\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><text x=\"65\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">0</text><text x=\"121\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"700\" fill=\"#16a34a\">1</text><text x=\"65\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">2</text><text x=\"121\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"700\" fill=\"#16a34a\">3</text><text x=\"241\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">4</text><text x=\"297\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">5</text><text x=\"241\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">6</text><text x=\"297\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">7</text><text x=\"20\" y=\"210\" font-size=\"16\" font-weight=\"600\"><tspan fill=\"#111827\">Index (</tspan><tspan fill=\"#dc2626\">0</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#f97316\">:</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#16a34a\">1</tspan><tspan fill=\"#111827\">)</tspan></text><text x=\"20\" y=\"246\" font-size=\"13\" fill=\"#334155\">Original shape: (2, 2, 2)</text><text x=\"20\" y=\"262\" font-size=\"13\" fill=\"#334155\">Index: 0, :, 1</text><text x=\"20\" y=\"278\" font-size=\"13\" fill=\"#334155\">Result shape: (2,)</text><text x=\"20\" y=\"294\" font-size=\"13\" fill=\"#334155\">Axis 0 is removed because integer index 0 is used.</text><text x=\"20\" y=\"310\" font-size=\"13\" fill=\"#334155\">Axis 1 is kept because slice : is used.</text><text x=\"20\" y=\"326\" font-size=\"13\" fill=\"#334155\">Axis 2 is removed because integer index 1 is used.</text></svg>"
       ],
       "text/plain": [
-       "<rainbow_tensor.notebook.TensorVisual at 0x1abb68f1b80>"
+       "<rainbow_tensor.notebook.TensorVisual at 0x2302801ffb0>"
       ]
      },
      "execution_count": 4,
@@ -144,7 +144,7 @@
     "import numpy as np\n",
     "\n",
     "x = np.arange(8).reshape(2, 2, 2)\n",
-    "show_index(x, (0, slice(None), 1))"
+    "rt.show_index(x, (0, slice(None), 1))"
    ]
   }
  ],

--- a/examples/shape_demo.ipynb
+++ b/examples/shape_demo.ipynb
@@ -16,15 +16,15 @@
    "id": "5f89716f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:18.282879Z",
-     "iopub.status.busy": "2026-06-16T02:10:18.282879Z",
-     "iopub.status.idle": "2026-06-16T02:10:18.290324Z",
-     "shell.execute_reply": "2026-06-16T02:10:18.290324Z"
+     "iopub.execute_input": "2026-06-16T02:12:50.127593Z",
+     "iopub.status.busy": "2026-06-16T02:12:50.127593Z",
+     "iopub.status.idle": "2026-06-16T02:12:50.134647Z",
+     "shell.execute_reply": "2026-06-16T02:12:50.134141Z"
     }
    },
    "outputs": [],
    "source": [
-    "from rainbow_tensor import show_shape"
+    "import rainbow_tensor as rt"
    ]
   },
   {
@@ -33,10 +33,10 @@
    "id": "e358eb70",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:18.293615Z",
-     "iopub.status.busy": "2026-06-16T02:10:18.293615Z",
-     "iopub.status.idle": "2026-06-16T02:10:18.297963Z",
-     "shell.execute_reply": "2026-06-16T02:10:18.297963Z"
+     "iopub.execute_input": "2026-06-16T02:12:50.135665Z",
+     "iopub.status.busy": "2026-06-16T02:12:50.135154Z",
+     "iopub.status.idle": "2026-06-16T02:12:50.139214Z",
+     "shell.execute_reply": "2026-06-16T02:12:50.139214Z"
     }
    },
    "outputs": [
@@ -46,7 +46,7 @@
        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"218\" height=\"158\" viewBox=\"0 0 218 158\" font-family=\"ui-monospace, Menlo, Consolas, monospace\"><rect x=\"20\" y=\"20\" width=\"178\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#111827\" stroke-width=\"3\"/><text x=\"53\" y=\"46\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">0</text><text x=\"109\" y=\"46\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">1</text><text x=\"165\" y=\"46\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">2</text><text x=\"20\" y=\"122\" font-size=\"16\" font-weight=\"600\"><tspan fill=\"#111827\">Shape (</tspan><tspan fill=\"#111827\">3</tspan><tspan fill=\"#111827\">)</tspan></text></svg>"
       ],
       "text/plain": [
-       "<rainbow_tensor.notebook.TensorVisual at 0x1870d592bd0>"
+       "<rainbow_tensor.notebook.TensorVisual at 0x1868f42aff0>"
       ]
      },
      "execution_count": 2,
@@ -55,7 +55,7 @@
     }
    ],
    "source": [
-    "show_shape((3,))"
+    "rt.show_shape((3,))"
    ]
   },
   {
@@ -64,10 +64,10 @@
    "id": "bd4c0c0e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:18.298967Z",
-     "iopub.status.busy": "2026-06-16T02:10:18.298967Z",
-     "iopub.status.idle": "2026-06-16T02:10:18.303358Z",
-     "shell.execute_reply": "2026-06-16T02:10:18.303358Z"
+     "iopub.execute_input": "2026-06-16T02:12:50.140748Z",
+     "iopub.status.busy": "2026-06-16T02:12:50.140227Z",
+     "iopub.status.idle": "2026-06-16T02:12:50.142777Z",
+     "shell.execute_reply": "2026-06-16T02:12:50.142777Z"
     }
    },
    "outputs": [
@@ -77,7 +77,7 @@
        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"218\" height=\"222\" viewBox=\"0 0 218 222\" font-family=\"ui-monospace, Menlo, Consolas, monospace\"><rect x=\"20\" y=\"20\" width=\"178\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"20\" y=\"84\" width=\"178\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><text x=\"53\" y=\"46\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">0</text><text x=\"109\" y=\"46\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">1</text><text x=\"165\" y=\"46\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">2</text><text x=\"53\" y=\"110\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">3</text><text x=\"109\" y=\"110\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">4</text><text x=\"165\" y=\"110\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">5</text><text x=\"20\" y=\"186\" font-size=\"16\" font-weight=\"600\"><tspan fill=\"#111827\">Shape (</tspan><tspan fill=\"#dc2626\">2</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#111827\">3</tspan><tspan fill=\"#111827\">)</tspan></text></svg>"
       ],
       "text/plain": [
-       "<rainbow_tensor.notebook.TensorVisual at 0x1870d5dadb0>"
+       "<rainbow_tensor.notebook.TensorVisual at 0x1868f022930>"
       ]
      },
      "execution_count": 3,
@@ -86,7 +86,7 @@
     }
    ],
    "source": [
-    "show_shape((2, 3))"
+    "rt.show_shape((2, 3))"
    ]
   },
   {
@@ -95,10 +95,10 @@
    "id": "bee4a6df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:18.304541Z",
-     "iopub.status.busy": "2026-06-16T02:10:18.304541Z",
-     "iopub.status.idle": "2026-06-16T02:10:18.307531Z",
-     "shell.execute_reply": "2026-06-16T02:10:18.307531Z"
+     "iopub.execute_input": "2026-06-16T02:12:50.143285Z",
+     "iopub.status.busy": "2026-06-16T02:12:50.143285Z",
+     "iopub.status.idle": "2026-06-16T02:12:50.146318Z",
+     "shell.execute_reply": "2026-06-16T02:12:50.146318Z"
     }
    },
    "outputs": [
@@ -108,7 +108,7 @@
        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"362\" height=\"246\" viewBox=\"0 0 362 246\" font-family=\"ui-monospace, Menlo, Consolas, monospace\"><rect x=\"20\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"32\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"32\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"196\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"208\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"208\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><text x=\"65\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">0</text><text x=\"121\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">1</text><text x=\"65\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">2</text><text x=\"121\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">3</text><text x=\"241\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">4</text><text x=\"297\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">5</text><text x=\"241\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">6</text><text x=\"297\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">7</text><text x=\"20\" y=\"210\" font-size=\"16\" font-weight=\"600\"><tspan fill=\"#111827\">Shape (</tspan><tspan fill=\"#dc2626\">2</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#f97316\">2</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#111827\">2</tspan><tspan fill=\"#111827\">)</tspan></text></svg>"
       ],
       "text/plain": [
-       "<rainbow_tensor.notebook.TensorVisual at 0x1870d6131d0>"
+       "<rainbow_tensor.notebook.TensorVisual at 0x1868f45ee10>"
       ]
      },
      "execution_count": 4,
@@ -117,7 +117,7 @@
     }
    ],
    "source": [
-    "show_shape((2, 2, 2))"
+    "rt.show_shape((2, 2, 2))"
    ]
   },
   {
@@ -134,10 +134,10 @@
    "id": "26094117",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-06-16T02:10:18.309043Z",
-     "iopub.status.busy": "2026-06-16T02:10:18.308038Z",
-     "iopub.status.idle": "2026-06-16T02:10:18.371926Z",
-     "shell.execute_reply": "2026-06-16T02:10:18.371418Z"
+     "iopub.execute_input": "2026-06-16T02:12:50.147326Z",
+     "iopub.status.busy": "2026-06-16T02:12:50.147326Z",
+     "iopub.status.idle": "2026-06-16T02:12:50.202200Z",
+     "shell.execute_reply": "2026-06-16T02:12:50.201692Z"
     }
    },
    "outputs": [
@@ -147,7 +147,7 @@
        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"362\" height=\"246\" viewBox=\"0 0 362 246\" font-family=\"ui-monospace, Menlo, Consolas, monospace\"><rect x=\"20\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"32\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"32\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"196\" y=\"20\" width=\"146\" height=\"140\" rx=\"6\" fill=\"none\" stroke=\"#dc2626\" stroke-width=\"3\"/><rect x=\"208\" y=\"32\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><rect x=\"208\" y=\"96\" width=\"122\" height=\"52\" rx=\"6\" fill=\"none\" stroke=\"#f97316\" stroke-width=\"3\"/><text x=\"65\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">0</text><text x=\"121\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">1</text><text x=\"65\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">2</text><text x=\"121\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">3</text><text x=\"241\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">4</text><text x=\"297\" y=\"58\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">5</text><text x=\"241\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">6</text><text x=\"297\" y=\"122\" text-anchor=\"middle\" dominant-baseline=\"central\" font-size=\"15\" font-weight=\"400\" fill=\"#111827\">7</text><text x=\"20\" y=\"210\" font-size=\"16\" font-weight=\"600\"><tspan fill=\"#111827\">Shape (</tspan><tspan fill=\"#dc2626\">2</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#f97316\">2</tspan><tspan fill=\"#111827\">, </tspan><tspan fill=\"#111827\">2</tspan><tspan fill=\"#111827\">)</tspan></text></svg>"
       ],
       "text/plain": [
-       "<rainbow_tensor.notebook.TensorVisual at 0x1870d642cf0>"
+       "<rainbow_tensor.notebook.TensorVisual at 0x186ad7a2ff0>"
       ]
      },
      "execution_count": 5,
@@ -159,7 +159,7 @@
     "import numpy as np\n",
     "\n",
     "x = np.arange(8).reshape(2, 2, 2)\n",
-    "show_shape(x)"
+    "rt.show_shape(x)"
    ]
   }
  ],

--- a/src/rainbow_tensor/__init__.py
+++ b/src/rainbow_tensor/__init__.py
@@ -6,10 +6,10 @@ tensor is structured and how an indexing expression selects elements.
 
 Public API:
 
-    from rainbow_tensor import show_shape, show_index
+    import rainbow_tensor as rt
 
-    show_shape((2, 2, 2))
-    show_index((2, 2, 2), (0, slice(None), 1))
+    rt.show_shape((2, 2, 2))
+    rt.show_index((2, 2, 2), (0, slice(None), 1))
 """
 
 from .notebook import show_index, show_shape


### PR DESCRIPTION
Closes #22.

Polishes the documentation for the published package.

Changes
- README installation now shows pip install rainbow-tensor first, with the from source option kept
- README usage examples use the import rainbow_tensor as rt convention and call rt.show_shape and rt.show_index
- the example notebooks use the same convention and were re-executed to refresh their outputs
- the package docstring example uses the rt convention