### PR TITLE
Add Sphinx documentation site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ ignore/
 
 # Artifact written by the save() demo in examples/shape_demo.ipynb
 examples/shape_2x2x2.svg
+docs/_build/

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,0 +1,38 @@
+API reference
+=============
+
+.. currentmodule:: rainbow_tensor
+
+Shape and indexing
+------------------
+
+.. autofunction:: shape
+.. autofunction:: index
+
+Shape changing and combining
+----------------------------
+
+.. autofunction:: reshape
+.. autofunction:: transpose
+.. autofunction:: sum
+.. autofunction:: mean
+.. autofunction:: concatenate
+.. autofunction:: stack
+.. autofunction:: broadcast
+
+Result object
+-------------
+
+.. autoclass:: TensorVisual
+   :members:
+
+Themes
+------
+
+.. autoclass:: Theme
+   :members:
+
+.. autofunction:: get_default_theme
+.. autofunction:: set_default_theme
+.. autofunction:: register_theme
+.. autofunction:: resolve_theme

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,47 @@
+"""Sphinx configuration for the rainbow-tensor documentation."""
+
+import os
+import sys
+from datetime import date
+
+# The package is pure standard library at import time, so adding the source
+# tree to the path is enough for autodoc; no install step is needed.
+sys.path.insert(0, os.path.abspath("../src"))
+
+project = "rainbow-tensor"
+author = "Zhixiang Feng"
+copyright = f"{date.today().year}, {author}"
+
+try:
+    from rainbow_tensor import __version__ as release
+except Exception:
+    release = "0.7.0"
+version = release
+
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
+    "myst_parser",
+]
+
+autodoc_member_order = "bysource"
+autodoc_default_options = {
+    "members": True,
+    "undoc-members": False,
+}
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+}
+
+myst_enable_extensions = ["colon_fence", "deflist"]
+
+templates_path = ["_templates"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+
+html_theme = "furo"
+html_title = "rainbow-tensor"
+html_static_path = ["_static"]

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,65 @@
+# rainbow-tensor
+
+rainbow-tensor visualises tensor shape, indexing, and slicing as SVG inside
+IPython and Jupyter notebooks. It is meant for anyone learning how a tensor is
+structured and how an indexing or a shape changing expression selects and moves
+elements.
+
+Every non-leaf axis draws a frame in its own rainbow colour, leaf elements sit
+in rounded cells, and a legend names each axis with its size in the matching
+colour. The same figure renders in a light or a dark theme without any change
+to your code.
+
+## Install
+
+```bash
+pip install rainbow-tensor
+```
+
+The distribution name is `rainbow-tensor` and the import name is
+`rainbow_tensor`.
+
+## Quick start
+
+Import the package as `rt`, then call one of the visualisation functions in a
+notebook cell so the SVG is displayed.
+
+```python
+import numpy as np
+import rainbow_tensor as rt
+
+x = np.arange(8).reshape(2, 2, 2)
+
+rt.shape(x)                          # draw the structure of a shape
+rt.index(x, (0, slice(None), 1))     # show how an index selects elements
+rt.reshape((2, 3), (3, 2))           # carry values into a new layout
+rt.broadcast((3, 1), (1, 4))         # stretch a smaller operand to match
+```
+
+Each function returns a small result object. Its `svg` attribute holds the SVG
+string, so the package stays inspectable and testable outside a notebook.
+
+## What it covers
+
+```{rubric} Shape and indexing
+```
+
+- Tensors of any rank, with frames nested to arbitrary depth
+- Integer indexing, basic slicing, `Ellipsis`, and `None` for a new axis
+- Boolean masks and integer array indexing, matching NumPy result shapes
+
+```{rubric} Shape changing and combining
+```
+
+- Reshape with row major order and one inferred `-1` axis
+- Transpose and permute with axis colours following the move
+- Sum and mean reductions over a chosen axis
+- Concatenate along an existing axis and stack onto a brand new axis
+- Broadcasting two tensors to a common shape, marking every stretched axis
+
+```{toctree}
+:maxdepth: 2
+:caption: Contents
+
+api
+```

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+sphinx>=7.0
+furo>=2024.1.29
+myst-parser>=2.0


### PR DESCRIPTION
Adds a Sphinx documentation site under `docs/`, ready to deploy on Cloudflare Pages.

## What

- `docs/conf.py` with autodoc, napoleon, viewcode, intersphinx, and MyST. The package is pure standard library at import time, so autodoc reads it straight from `../src` with no install step.
- `docs/index.md` landing page and `docs/api.rst` API reference covering every public function, `TensorVisual`, and the theme helpers.
- `docs/requirements.txt` pinning sphinx, furo, and myst-parser for the Cloudflare build.

Build locally with `sphinx-build -b html docs docs/_build/html`. The build passes with warnings treated as errors.