### PR TITLE
Add wrangler static assets config

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,7 @@
+{
+  "name": "rainbow-tensor",
+  "compatibility_date": "2026-06-18",
+  "assets": {
+    "directory": "docs/_build/html"
+  }
+}


### PR DESCRIPTION
Adds `wrangler.jsonc` so the Cloudflare Workers build deploys the Sphinx output as static assets.

The deploy command is `npx wrangler deploy`, which reads this config and uploads `docs/_build/html`.