### PR TITLE
Fix broken ellipsis glyphs in skipped tensor positions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.10.1
+
+### Fixed
+
+- Skipped tensor positions in a large preview now always draw the intended ellipsis glyphs. The horizontal, vertical, and midline ellipsis are defined with ASCII unicode escapes so a non-UTF-8 re-save of the source can no longer corrupt them into broken text
+
 ## 0.10.0
 
 ### Added

--- a/src/rainbow_tensor/layout.py
+++ b/src/rainbow_tensor/layout.py
@@ -24,10 +24,11 @@ from .theme import LIGHT
 # A sentinel marking a hidden run of positions along an axis.
 ELLIPSIS = object()
 
-# The glyph drawn for the gap, chosen to match the axis orientation.
-COL_ELLIPSIS = "…"  # horizontal ellipsis for a hidden column run
-ROW_ELLIPSIS = "⋮"  # vertical ellipsis for a hidden row run
-BLOCK_ELLIPSIS = "⋯"  # midline ellipsis for a hidden block run
+# The glyph drawn for the gap, chosen to match the axis orientation. Written as
+# ASCII unicode escapes so a non-UTF-8 re-save of this file cannot corrupt them.
+COL_ELLIPSIS = "\u2026"  # horizontal ellipsis for a hidden column run
+ROW_ELLIPSIS = "\u22ee"  # vertical ellipsis for a hidden row run
+BLOCK_ELLIPSIS = "\u22ef"  # midline ellipsis for a hidden block run
 
 
 @dataclass

--- a/tests/test_polish.py
+++ b/tests/test_polish.py
@@ -9,7 +9,14 @@ import re
 import pytest
 
 import rainbow_tensor as rt
-from rainbow_tensor.layout import COL_ELLIPSIS, ELLIPSIS, build_layout, visible_positions
+from rainbow_tensor.layout import (
+    BLOCK_ELLIPSIS,
+    COL_ELLIPSIS,
+    ELLIPSIS,
+    ROW_ELLIPSIS,
+    build_layout,
+    visible_positions,
+)
 
 
 def _width(svg):
@@ -32,6 +39,21 @@ def test_visible_positions_truncates_long_axis():
 def test_long_axis_draws_ellipsis_cell():
     visual = rt.shape((30,))
     assert COL_ELLIPSIS in visual.svg
+
+
+def test_skipped_glyphs_are_the_exact_codepoints():
+    # Pin the exact glyphs so a non-UTF-8 re-save of layout.py that corrupts the
+    # source literals fails here instead of shipping broken text in a preview.
+    assert (COL_ELLIPSIS, ROW_ELLIPSIS, BLOCK_ELLIPSIS) == ("…", "⋮", "⋯")
+
+
+def test_truncated_high_rank_tensor_renders_all_three_glyphs():
+    # A 3D tensor truncated on every axis draws a hidden column run, row run, and
+    # block run, so all three intended glyphs must appear verbatim in the SVG.
+    svg = rt.shape((30, 30, 30)).svg
+    assert "…" in svg  # … horizontal ellipsis
+    assert "⋮" in svg  # ⋮ vertical ellipsis
+    assert "⋯" in svg  # ⋯ midline ellipsis
 
 
 def test_long_axis_stays_bounded_in_width():


### PR DESCRIPTION
Closes #49.

Skipped positions in a large tensor preview draw three glyphs: a horizontal ellipsis for a hidden column run, a vertical ellipsis for a hidden row run, and a midline ellipsis for a hidden block run. They were written as raw multibyte literals in layout.py, which corrupt into broken text if the file is ever re-saved under a non-UTF-8 editor.

Changes:
- define the three glyphs with ASCII unicode escapes, so the output no longer depends on the source file encoding
- add a test that pins the exact glyph codepoints and a test that asserts all three appear verbatim in a truncated high rank preview
- note the fix in the changelog

The rendered bytes are unchanged, so no golden snapshot needed regeneration. pytest, ruff, and build all pass.