### PR TITLE
Fix reduction result frame colours for non-last axis

### DIFF
--- a/src/rainbow_tensor/notebook.py
+++ b/src/rainbow_tensor/notebook.py
@@ -1088,6 +1088,20 @@ def _reduce(array, axis, op_name, combine, theme, precision, renderer):
 
     disp = result or (1,)
 
+    # The surviving axes keep their original source colours instead of being
+    # recoloured by their new position, so reducing a non-last axis does not
+    # swap an axis frame to a different colour.
+    surviving = [i for i in range(len(shape)) if i != axis]
+    if result:
+        result_theme = theme.variant(
+            axis_colors=tuple(theme.axis_color(surviving[r]) for r in range(len(result)))
+        )
+    else:
+        result_theme = theme
+
+    def result_color(ax):
+        return result_theme.axis_color(ax) if ax < len(result) - 1 else theme.text_muted
+
     # The result element of each group takes the same background as its source
     # group, so a result cell and the values that fold into it read as one unit.
     def result_tint(coord):
@@ -1122,7 +1136,10 @@ def _reduce(array, axis, op_name, combine, theme, precision, renderer):
             "value_fn": result_value,
             "selected": selected_result,
             "cell_tint": result_tint,
-            "caption_parts": _shape_caption_parts(op_name, disp, theme),
+            "theme": result_theme,
+            "caption_parts": _shape_caption_parts(
+                op_name, disp, theme, color_for=result_color
+            ),
         },
     ]
     content = renderer.render_panels(

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -275,6 +275,19 @@ def test_reduce_to_scalar_renders():
     assert visual.svg.startswith("<svg")
 
 
+def test_reduce_result_keeps_surviving_axis_colours():
+    # Reducing a non-last axis must not recolour the surviving axes by their new
+    # position. Reducing axis 0 of (2, 3, 4) leaves (3, 4); the surviving "3"
+    # axis keeps the source axis 1 colour rather than taking the axis 0 colour.
+    from rainbow_tensor.theme import resolve_theme
+
+    theme = resolve_theme(None)
+    svg = rt.mean(np.arange(24).reshape(2, 3, 4), 0).svg
+    assert theme.axis_color(1) in svg  # surviving axis keeps its source colour
+    # and the result panel never paints that frame in the reduced axis 0 colour
+    assert f'mean (</tspan><tspan fill="{theme.axis_color(0)}">3' not in svg
+
+
 SQUEEZE_CASES = [
     ((1, 3), None),
     ((3, 1), None),


### PR DESCRIPTION
Fixes #75.

rt.sum and rt.mean now keep each surviving axis in its original source colour when a non-last axis is reduced, instead of recolouring axes by their new position. Applies to the result panel frames and the shape caption, mirroring how squeeze and transpose preserve axis colours.

- bug(notebook): map surviving result axes back to their source axis colours
- test: a (2,3,4) mean over axis 0 keeps the surviving axis colour

All 332 tests pass; golden renders unchanged.