### PR TITLE
Fix ruff import grouping in example notebooks

### DIFF
--- a/examples/01_shapes.ipynb
+++ b/examples/01_shapes.ipynb
@@ -25,6 +25,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "\n",
     "import rainbow_tensor as rt"
    ]
   },

--- a/examples/02_indexing.ipynb
+++ b/examples/02_indexing.ipynb
@@ -25,6 +25,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "\n",
     "import rainbow_tensor as rt"
    ]
   },

--- a/examples/03_reshaping.ipynb
+++ b/examples/03_reshaping.ipynb
@@ -25,6 +25,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "\n",
     "import rainbow_tensor as rt"
    ]
   },

--- a/examples/04_reductions_and_math.ipynb
+++ b/examples/04_reductions_and_math.ipynb
@@ -25,6 +25,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "\n",
     "import rainbow_tensor as rt"
    ]
   },

--- a/examples/05_combining.ipynb
+++ b/examples/05_combining.ipynb
@@ -25,6 +25,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "\n",
     "import rainbow_tensor as rt"
    ]
   },

--- a/examples/06_themes_and_backends.ipynb
+++ b/examples/06_themes_and_backends.ipynb
@@ -25,6 +25,7 @@
    "outputs": [],
    "source": [
     "import numpy as np\n",
+    "\n",
     "import rainbow_tensor as rt"
    ]
   },


### PR DESCRIPTION
Ruff treats rainbow_tensor as a first party import, so the two import lines must sit in separate groups. Applies the ruff autofix to all six notebooks.