### PR TITLE
Add a structured user guide to the documentation

### DIFF
--- a/docs/guide/combining.md
+++ b/docs/guide/combining.md
@@ -1,0 +1,65 @@
+# Combining tensors
+
+These views join several tensors into one or stretch one to a new shape. Each
+operand is drawn in its own tint, so the seam between operands or the new axis
+stays clear.
+
+```python
+import numpy as np
+import rainbow_tensor as rt
+
+a = np.arange(6).reshape(2, 3)
+b = np.arange(100, 106).reshape(2, 3)
+```
+
+## Concatenate and stack
+
+`concatenate` joins operands along an existing axis, and the sizes may differ on
+that axis. `stack` places the operands onto a brand new axis, so every operand
+keeps its full shape. A mismatch raises a clear error rather than drawing a
+wrong figure.
+
+```python
+rt.concatenate([a, b], 0)
+rt.concatenate([a, b], 1)
+rt.stack([a, b], 0)
+```
+
+## Broadcast
+
+`broadcast` stretches a smaller operand to match a larger one. Each operand is
+drawn in its own shape and again stretched to the common shape, so the repeated
+values along a stretched axis are visible and every stretched axis is marked.
+Axes line up from the right, and on each axis the sizes must be equal or one of
+them must be `1`.
+
+```python
+rt.broadcast((3, 1), (1, 4))
+rt.broadcast((2, 3, 4), (4,))
+```
+
+## Repeat
+
+`repeat` copies elements along an axis. A single count repeats every element, or
+one count per element repeats each by its own amount, matching `numpy.repeat`.
+Each source element and the run of copies it produces share one tint, so the
+result reads as real materialised copies. This is the contrast with `broadcast`,
+which only stretches a size one axis and copies nothing.
+
+```python
+x = np.arange(12).reshape(3, 4)
+rt.repeat(x, 2, axis=0)
+rt.repeat(x, [1, 2, 0, 1], axis=1)
+```
+
+## Take
+
+`take` gathers values along one axis from a list of indices, matching
+`numpy.take`. Each gathered source slice and the result slice it feeds share one
+tint, so a repeated index repeats a tint and a reordered index reorders them.
+Negative axes and negative indices both work.
+
+```python
+rt.take(x, [0, 2, 2, 1], axis=1)
+rt.take(x, [2, 0], axis=0)
+```

--- a/docs/guide/indexing.md
+++ b/docs/guide/indexing.md
@@ -1,0 +1,71 @@
+# Indexing
+
+`index` shows how an indexing expression selects elements. The selected cells
+fill green and the selected frames keep their colour, while the rest of the
+tensor dims so the selected path stands out.
+
+```python
+import numpy as np
+import rainbow_tensor as rt
+
+x = np.arange(8).reshape(2, 2, 2)
+rt.index(x, (0, slice(None), 1))
+```
+
+For this array the index `(0, slice(None), 1)` selects the values `1` and `3`,
+the selected coordinates are `(0, 0, 1)` and `(0, 1, 1)`, and the result shape
+is `(2,)`.
+
+## Integers and slices
+
+An integer drops an axis. A slice keeps it. Slice bounds and steps may be
+negative, so `slice(4, 1, -1)` walks backwards.
+
+```python
+rt.index(np.arange(5), (slice(4, 1, -1),))
+```
+
+## Ellipsis and a new axis
+
+`Ellipsis` fills the axes you leave out, so `(0, ..., 1)` keeps the middle axis.
+`None` inserts a size one axis that shows up in the result shape and label.
+
+```python
+rt.index(np.arange(12).reshape(2, 3, 2), (0, ..., 1))
+rt.index(np.arange(6).reshape(2, 3), (None, 1, slice(None)))
+```
+
+## Boolean masks
+
+A boolean mask of matching shape highlights every True position. A boolean
+array on a single axis acts like its nonzero integer array and mixes with
+slices and integer indices.
+
+```python
+x = np.arange(20).reshape(4, 5)
+rt.index(x, x % 3 == 0)
+```
+
+## Fancy indexing
+
+Integer arrays gather coordinates. Paired arrays pick one element each, and
+multi-dimensional index arrays broadcast together and may mix with slices, with
+the gathered block placed where NumPy puts it.
+
+```python
+x = np.arange(20).reshape(4, 5)
+rt.index(x, ([0, 2, 3], [1, 4, 0]))
+```
+
+## Clear errors
+
+An out of range index points at the offending axis instead of failing deep
+inside NumPy.
+
+```python
+x = np.arange(8).reshape(2, 2, 2)
+try:
+    rt.index(x, (2, slice(None), 1))
+except IndexError as error:
+    print(error)
+```

--- a/docs/guide/reductions-and-math.md
+++ b/docs/guide/reductions-and-math.md
@@ -1,0 +1,56 @@
+# Reductions and math
+
+These views collapse or contract axes. The source and the result sit side by
+side so the reduced or contracted axis is easy to see.
+
+```python
+import numpy as np
+import rainbow_tensor as rt
+```
+
+## Sum and mean
+
+`sum` and `mean` collapse one axis. The source values that fold into the same
+result element share one background colour with that result element, the first
+group stays highlighted, and every surviving axis keeps its original colour.
+`mean` divides each group by its count, so the result holds floats.
+
+```python
+rt.sum(np.arange(24).reshape(2, 3, 4), 0)
+rt.mean(np.arange(24).reshape(2, 3, 4), 1)
+```
+
+## Matmul
+
+`matmul` draws `a @ b` as the two operands and the output. The shared inner axis
+is marked in the accent colour, and the row and column that combine into the
+first output element are highlighted, so the contraction reads straight off the
+figure. Vector, matrix, and batched products all work, and the batch axes
+broadcast like `numpy.matmul`.
+
+```python
+a = np.arange(6).reshape(2, 3)
+b = np.arange(12).reshape(3, 4)
+
+rt.matmul(a, b)
+rt.matmul(np.arange(3), b)
+rt.matmul(np.ones((5, 2, 3)), np.ones((5, 3, 4)))
+```
+
+## Einsum
+
+`einsum` turns a subscript expression into labelled operand panels and an output
+panel. Every label is coloured by its role, so free, shared, and contracted
+labels read as three distinct groups, and a label keeps that colour across every
+operand and the output. An ellipsis stands for the broadcast axes a subscript
+leaves unnamed.
+
+```python
+rt.einsum("ij,jk->ik", a, b)
+rt.einsum("abc,cde,ef->abdf", (2, 2, 2), (2, 2, 2), (2, 2))
+rt.einsum("...ij,...jk->...ik", (2, 2, 3), (2, 3, 4))
+```
+
+The output shape is derived from the free labels and checked with the same size
+rules as NumPy. A dedicated `matmul` view exists for the common matrix multiply
+that `einsum("ik,kj->ij", a, b)` also expresses.

--- a/docs/guide/reshaping.md
+++ b/docs/guide/reshaping.md
@@ -1,0 +1,56 @@
+# Reshaping and moving axes
+
+These views rearrange a tensor without changing its values. The source and the
+result sit in one figure with a connector, and each axis keeps its colour so you
+can trace where it lands.
+
+```python
+import numpy as np
+import rainbow_tensor as rt
+
+x = np.arange(12).reshape(3, 4)
+```
+
+## Reshape
+
+Reshape keeps the row major order, so element k stays element k while the layout
+changes. A single `-1` lets one axis be inferred from the rest.
+
+```python
+rt.reshape(x, (2, 6))
+rt.reshape(np.arange(24).reshape(2, 3, 4), (-1, 4))
+```
+
+## Transpose and swapaxes
+
+`transpose` reverses or permutes the axes, colouring each result axis by the
+source axis it came from. `swapaxes` does the same for exactly two axes, with
+negative axes resolved like NumPy.
+
+```python
+rt.transpose(x)
+rt.transpose(x, (1, 0))
+rt.swapaxes(np.arange(24).reshape(2, 3, 4), 0, 2)
+```
+
+## Moveaxis
+
+`moveaxis` moves one or several axes to chosen destinations while the rest keep
+their order, and each moved axis keeps its source colour.
+
+```python
+rt.moveaxis(np.arange(24).reshape(2, 3, 4), 0, 2)
+```
+
+## Squeeze and expand_dims
+
+`squeeze` removes size one axes, either every one of them or a chosen axis or
+tuple, and marks the removed axes while each surviving axis keeps its colour.
+`expand_dims` inserts a size one axis at a positive or negative position and
+marks the inserted axis in the accent colour.
+
+```python
+rt.squeeze(np.ones((1, 3, 1)))
+rt.squeeze(np.ones((1, 3, 1)), 0)
+rt.expand_dims(x, 1)
+```

--- a/docs/guide/shapes.md
+++ b/docs/guide/shapes.md
@@ -1,0 +1,68 @@
+# Shapes
+
+`shape` draws the structure of a tensor. Every non-leaf axis becomes a coloured
+frame, leaf elements sit in rounded cells, and a legend names each axis with its
+size in the matching colour.
+
+```python
+import numpy as np
+import rainbow_tensor as rt
+
+rt.shape(np.arange(3))                    # a vector
+rt.shape(np.arange(6).reshape(2, 3))      # a matrix
+rt.shape(np.arange(8).reshape(2, 2, 2))   # a cube
+rt.shape(np.arange(16).reshape(2, 2, 2, 2))
+```
+
+The same call works on a shape tuple or on any array-like object that exposes a
+`.shape` attribute, so no array library is imported by the core.
+
+## Colour scheme
+
+Each axis has its own colour drawn from a rainbow ramp keyed by depth, so the
+structure stays readable at any rank.
+
+- Axis 0 is the outer frame, drawn red
+- Axis 1 is the inner row frame, drawn orange
+- Deeper axes move through lime, teal, blue, violet, and pink, so adjacent axes
+  stay easy to tell apart
+- Leaf elements sit in plain cells, and a selected element fills green
+- The shape label, the index label, and the legend swatches all match
+
+## Float precision
+
+Floats format to a chosen number of decimals, right aligned for easy reading.
+
+```python
+x = np.linspace(0, 1, 6).reshape(2, 3)
+rt.shape(x, precision=3)
+```
+
+## Saving to a file
+
+Every result carries its SVG and can write it straight to disk.
+
+```python
+visual = rt.shape(np.arange(8).reshape(2, 2, 2))
+visual.save("tensor.svg")
+```
+
+## Big tensor previews
+
+Large tensors use two limits. `max_cells` caps one axis, while
+`max_visible_cells` caps the whole preview, so a high rank tensor does not draw
+a huge SVG. The preview keeps the head and tail of each hidden axis.
+
+```python
+rt.shape((100, 100, 100, 100))
+```
+
+## Explanation text
+
+Explanations print as plain notebook output below the figure, and the same text
+stays available in Python through the `text` attribute.
+
+```python
+visual = rt.index((2, 2, 2), (0, slice(None), 1))
+visual.text
+```

--- a/docs/guide/themes-and-configuration.md
+++ b/docs/guide/themes-and-configuration.md
@@ -1,0 +1,85 @@
+# Themes and configuration
+
+Every view shares one theme system and reads values through a tiny adapter, so
+the look and the input source are both flexible.
+
+## Themes
+
+Pass `theme="light"` or `theme="dark"` to any call, or set a module default that
+every later call follows.
+
+```python
+import numpy as np
+import rainbow_tensor as rt
+
+x = np.arange(8).reshape(2, 2, 2)
+rt.shape(x, theme="dark")
+
+rt.set_default_theme("dark")
+rt.index(x, (0, slice(None), 1))
+```
+
+A theme bundles the colours, fonts, cell size, stroke width, the per axis
+truncation limit, and the total visible cell budget. Derive a tweaked copy with
+`variant` and pass it directly.
+
+```python
+roomy = rt.LIGHT.variant(cell_w=64, max_cells=8, max_visible_cells=160)
+rt.shape(np.arange(8).reshape(2, 4), theme=roomy)
+```
+
+## Global axis colours
+
+To recolour the axis frames everywhere without building a whole theme, set an
+axis ramp once with `set_default_axis_colors`. Each colour maps to one axis
+depth, and the ramp wraps for deeper tensors. It applies to every later call
+that does not pass its own `theme`, so a per call `theme` still wins.
+
+```python
+rt.set_default_axis_colors(["#2563eb", "#db2777", "#16a34a"])
+rt.shape((2, 2, 2))
+rt.shape((2, 2, 2), theme="dark")   # the per call theme keeps its own ramp
+rt.set_default_axis_colors(None)    # clear it and fall back to the theme ramp
+```
+
+`get_default_axis_colors` returns the current ramp, or `None` when none is set.
+
+## Backend arrays
+
+rainbow-tensor reads arrays through duck typing. If an object exposes a `.shape`
+attribute and supports coordinate reads, the visualiser can draw its values
+without importing that backend in the core package. NumPy, PyTorch, JAX, and
+TensorFlow style arrays all work.
+
+```python
+import torch
+import jax.numpy as jnp
+
+rt.shape(torch.arange(6).reshape(2, 3))
+rt.shape(jnp.arange(6).reshape(2, 3))
+```
+
+## Renderers
+
+SVG is the default renderer. A custom renderer can be registered for other
+output formats, and it receives the same shape, panels, value functions, theme,
+and precision that the SVG renderer uses.
+
+```python
+class TextRenderer:
+    name = "text"
+    mime_type = "text/plain"
+
+    def render_tensor(self, **kwargs):
+        return str(kwargs["shape"])
+
+    def render_panels(self, **kwargs):
+        return str(kwargs["panels"][-1]["shape"])
+
+
+rt.register_renderer(TextRenderer())
+rt.shape((2, 3), renderer="text")
+```
+
+Use `set_default_renderer` to choose a renderer for later calls, or pass
+`renderer=` on one call for a local override.

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,26 +44,39 @@ figure, so the package stays inspectable and testable outside a notebook.
 
 ## What it covers
 
-```{rubric} Shape and indexing
-```
+The user guide walks through each feature group in order, mirroring the runnable
+notebooks in the `examples` folder.
 
-- Tensors of any rank, with frames nested to arbitrary depth
-- Big tensor previews with a total visible cell budget
-- Integer indexing, basic slicing, `Ellipsis`, and `None` for a new axis
-- Boolean masks and integer array indexing, matching NumPy result shapes
-
-```{rubric} Shape changing and combining
-```
-
-- Reshape with row major order and one inferred `-1` axis
-- Transpose and permute with axis colours following the move
-- Sum and mean reductions over a chosen axis
-- Concatenate along an existing axis and stack onto a brand new axis
-- Broadcasting two tensors to a common shape, marking every stretched axis
+- [Shapes](guide/shapes) draws a tensor and explains the colour scheme, float
+  precision, saving, and big tensor previews
+- [Indexing](guide/indexing) covers integers, slices, ellipsis, new axes,
+  boolean masks, and fancy integer arrays
+- [Reshaping and moving axes](guide/reshaping) covers reshape, transpose,
+  swapaxes, moveaxis, squeeze, and expand_dims
+- [Reductions and math](guide/reductions-and-math) covers sum, mean, matmul,
+  and einsum
+- [Combining tensors](guide/combining) covers concatenate, stack, broadcast,
+  repeat, and take
+- [Themes and configuration](guide/themes-and-configuration) covers themes,
+  global axis colours, backend arrays, and renderers
 
 ```{toctree}
 :maxdepth: 2
-:caption: Contents
+:caption: User guide
+:hidden:
+
+guide/shapes
+guide/indexing
+guide/reshaping
+guide/reductions-and-math
+guide/combining
+guide/themes-and-configuration
+```
+
+```{toctree}
+:maxdepth: 2
+:caption: Reference
+:hidden:
 
 api
 ```


### PR DESCRIPTION
Fixes #82.

Adds a user guide so the docs read in a clear order instead of jumping from the index straight to the API reference.

- one guide page per feature group, mirroring the example notebooks
- shapes, indexing, reshaping and moving axes, reductions and math, combining, themes and configuration
- the index toctree now has a User guide section and a Reference section
- every public function is covered

Builds clean with no Sphinx warnings.