### PR TITLE
Centralize explanations, add language support, and centralise config

### DIFF
--- a/docs/guide/themes-and-configuration.md
+++ b/docs/guide/themes-and-configuration.md
@@ -44,6 +44,23 @@ rt.set_default_axis_colors(None)    # clear it and fall back to the theme ramp
 
 `get_default_axis_colors` returns the current ramp, or `None` when none is set.
 
+## Explanation language
+
+Every caption line under a visual comes from a keyed template in
+`rainbow_tensor.explanations`. The active language is global. Set it once with
+`set_language`, and `get_language` returns the current one.
+
+```python
+rt.set_language("de")   # affects every later visual
+rt.get_language()       # -> "de"
+rt.set_language("en")   # back to the default
+```
+
+Only English (`"en"`) ships today. A translation adds one table to
+`MESSAGES` keyed by its language code, reusing the English keys. English is the
+fallback at two levels, so an unknown language or a key a translation has not
+filled yet still renders the English line rather than failing.
+
 ## Backend arrays
 
 rainbow-tensor reads arrays through duck typing. If an object exposes a `.shape`

--- a/src/rainbow_tensor/__init__.py
+++ b/src/rainbow_tensor/__init__.py
@@ -15,6 +15,7 @@ Public API:
     rt.set_default_theme("dark")
 """
 
+from .explanations import get_language, set_language
 from .notebook import (
     TensorVisual,
     broadcast,
@@ -90,5 +91,7 @@ __all__ = [
     "set_default_axis_colors",
     "register_theme",
     "resolve_theme",
+    "set_language",
+    "get_language",
     "__version__",
 ]

--- a/src/rainbow_tensor/config.py
+++ b/src/rainbow_tensor/config.py
@@ -1,0 +1,17 @@
+"""Single home for all mutable global configuration.
+
+The theme, renderer, and explanation modules keep their own logic, but every
+default a user can change lives here, so there is one place to read or reset the
+whole configuration. The object defaults start as ``None`` sentinels meaning
+"use the built in default", so this module imports nothing from the package and
+can never cause an import cycle.
+"""
+
+# None -> theme.LIGHT
+default_theme = None
+# None -> each theme's own axis colour ramp
+default_axis_colors = None
+# None -> renderers.SVG
+default_renderer = None
+# explanation language; "en" is always the fallback
+language = "en"

--- a/src/rainbow_tensor/explanations.py
+++ b/src/rainbow_tensor/explanations.py
@@ -4,14 +4,16 @@ Every caption line shown under a visual is built from a keyed template here,
 instead of being inlined as an f-string next to the render logic. This keeps
 the wording in one place to copy edit, and gives a single point to translate.
 
-The active language is a module global set with :func:`set_language`. English
-(``"en"``) is the fallback at two levels: an unknown language falls back to the
-whole ``en`` table, and a key missing from a translation falls back to its
-``en`` string, so a partial translation never raises.
+The active language lives in :mod:`rainbow_tensor.config` and is set with
+:func:`set_language`. English (``"en"``) is the fallback at two levels: an
+unknown language falls back to the whole ``en`` table, and a key missing from a
+translation falls back to its ``en`` string, so a partial translation never
+raises.
 """
 
+from . import config
+
 _DEFAULT = "en"
-_language = _DEFAULT
 
 MESSAGES = {
     "en": {
@@ -120,13 +122,12 @@ MESSAGES = {
 
 def set_language(lang):
     """Set the active language for all subsequent explanations."""
-    global _language
-    _language = lang
+    config.language = lang
 
 
 def get_language():
     """Return the active explanation language."""
-    return _language
+    return config.language
 
 
 def t(key, **kwargs):
@@ -134,20 +135,6 @@ def t(key, **kwargs):
 
     Falls back to English for an unknown language or a missing key.
     """
-    table = MESSAGES.get(_language, MESSAGES[_DEFAULT])
+    table = MESSAGES.get(config.language, MESSAGES[_DEFAULT])
     template = table.get(key) or MESSAGES[_DEFAULT][key]
     return template.format(**kwargs)
-
-
-if __name__ == "__main__":
-    # ponytail: smallest check that the two fallback levels and formatting hold.
-    assert t("swapaxes.swap", a=0, b=2) == "Swapping axes 0 and 2."
-    set_language("de")  # no German table yet, falls back to the en table
-    assert t("common.result_shape", shape="(2,)") == "Result shape: (2,)"
-    MESSAGES["de"] = {"swapaxes.swap": "Tausche Achsen {a} und {b}."}
-    assert t("swapaxes.swap", a=0, b=2) == "Tausche Achsen 0 und 2."
-    # missing key in a partial table still falls back to en
-    assert t("common.result_shape", shape="(2,)") == "Result shape: (2,)"
-    del MESSAGES["de"]
-    set_language("en")
-    print("ok")

--- a/src/rainbow_tensor/explanations.py
+++ b/src/rainbow_tensor/explanations.py
@@ -89,7 +89,9 @@ MESSAGES = {
         # concatenate
         "concatenate.operands": "Operand shapes: {shapes}",
         "concatenate.joining": "Joining along axis {axis}.",
-        "concatenate.seam": "Each operand keeps its tint, so the seam along the joined axis is clear.",
+        "concatenate.seam": (
+            "Each operand keeps its tint, so the seam along the joined axis is clear."
+        ),
         # stack
         "stack.operand": "Operand shape: {shape}",
         "stack.stacking": "Stacking {count} tensors on a new axis {axis}.",

--- a/src/rainbow_tensor/explanations.py
+++ b/src/rainbow_tensor/explanations.py
@@ -1,0 +1,151 @@
+"""Centralised explanation text for the notebook display layer.
+
+Every caption line shown under a visual is built from a keyed template here,
+instead of being inlined as an f-string next to the render logic. This keeps
+the wording in one place to copy edit, and gives a single point to translate.
+
+The active language is a module global set with :func:`set_language`. English
+(``"en"``) is the fallback at two levels: an unknown language falls back to the
+whole ``en`` table, and a key missing from a translation falls back to its
+``en`` string, so a partial translation never raises.
+"""
+
+_DEFAULT = "en"
+_language = _DEFAULT
+
+MESSAGES = {
+    "en": {
+        # shared across many ops
+        "common.original_shape": "Original shape: {shape}",
+        "common.new_shape": "New shape: {shape}",
+        "common.result_shape": "Result shape: {shape}",
+        "common.axes_order": "Axes order: {order}",
+        "common.index": "Index: {index}",
+        # large tensor preview
+        "preview.large_single": (
+            "Large preview for tensor {shape} draws at most {max} real cells "
+            "from {total} total."
+        ),
+        "preview.large_multi": (
+            "Large preview for tensor {i} {shape} draws at most {max} real cells "
+            "from {total} total."
+        ),
+        "preview.hidden": "Hidden axes {hidden} keep the head, selected positions, and tail.",
+        # reshape
+        "reshape.row_major": (
+            "Values keep their row major order, so element k stays element k."
+        ),
+        # transpose
+        "transpose.keep_colour": "Each axis keeps its colour as it moves to its new position.",
+        # swapaxes
+        "swapaxes.swap": "Swapping axes {a} and {b}.",
+        "swapaxes.keep_colour": "The two moved axes keep their source colours in the result.",
+        # moveaxis
+        "moveaxis.move": "Moving axes {source} to {destination}.",
+        "moveaxis.keep_colour": "Each moved axis keeps its source colour in the result.",
+        # squeeze
+        "squeeze.removing": "Removing size one axes {axes}.",
+        "squeeze.none": "No size one axes to remove.",
+        "squeeze.keep_colour": (
+            "Each surviving axis keeps its colour, and the removed size one axes are marked."
+        ),
+        # expand_dims
+        "expand_dims.inserting": "Inserting size one axes at {axes}.",
+        "expand_dims.keep_colour": (
+            "Each existing axis keeps its colour, and the inserted size one axes are marked."
+        ),
+        # matmul
+        "matmul.operands": "Operand shapes: {a} @ {b}",
+        "matmul.dims": "Left rows: {rows}, right columns: {cols}, shared inner axis: {inner}.",
+        "matmul.combine": (
+            "The shared inner axis is marked, and the highlighted row and column "
+            "combine into the first output element."
+        ),
+        # repeat
+        "repeat.repeating": "Repeating {repeats} along axis {axis}.",
+        "repeat.copies": (
+            "Each source element is copied into its own run of result cells, so "
+            "repeat materialises real copies, unlike broadcast which stretches a "
+            "size one axis virtually."
+        ),
+        # take
+        "take.taking": "Taking indices {indices} along axis {axis}.",
+        "take.copies": (
+            "Each result slice copies a source slice, so repeated indices repeat a "
+            "slice and reordered indices reorder them."
+        ),
+        # reduce (sum, mean, ...)
+        "reduce.reducing": "Reducing axis {axis} with {op}.",
+        "reduce.combines": "Each result element combines {count} values from axis {axis}.",
+        "reduce.share_background": (
+            "Values that fold into the same result share one background with that "
+            "result element, and the first group is highlighted."
+        ),
+        # einsum
+        "einsum.operand_subscripts": "Operand subscripts: {subscripts}",
+        "einsum.output_subscript": "Output subscript: {subscript}",
+        "einsum.contracted": "Contracted labels: {labels}",
+        "einsum.none_contracted": "No labels are contracted.",
+        # concatenate
+        "concatenate.operands": "Operand shapes: {shapes}",
+        "concatenate.joining": "Joining along axis {axis}.",
+        "concatenate.seam": "Each operand keeps its tint, so the seam along the joined axis is clear.",
+        # stack
+        "stack.operand": "Operand shape: {shape}",
+        "stack.stacking": "Stacking {count} tensors on a new axis {axis}.",
+        "stack.new_axis": "The new axis indexes the operands, each kept in its own tint.",
+        # broadcast
+        "broadcast.operands": "Operand shapes: {a} and {b}",
+        "broadcast.stretches": "operand {i} {shape} stretches axes {axes}",
+        "broadcast.matches": "operand {i} {shape} already matches",
+        "broadcast.fill": (
+            "A stretched axis repeats one value, so both operands fill the result shape."
+        ),
+        # index
+        "index.new_axis": "A new size 1 axis is inserted by None at result position {pos}.",
+        "index.axis_removed": "Axis {axis} is removed because integer index {index} is used.",
+        "index.axis_kept": "Axis {axis} is kept because slice {slice} is used.",
+        "index.mask": "Advanced indexing with a boolean mask.",
+        "index.mask_keeps": "The mask keeps {count} element{plural} where it is True.",
+        "index.arrays": "Advanced indexing with integer arrays.",
+        "index.gather": "Axes {axes} gather {count} position{plural} in shape {shape}.",
+        "index.slice_separates": (
+            "A slice separates the gathered axes, so the gathered axis moves to the front."
+        ),
+    },
+}
+
+
+def set_language(lang):
+    """Set the active language for all subsequent explanations."""
+    global _language
+    _language = lang
+
+
+def get_language():
+    """Return the active explanation language."""
+    return _language
+
+
+def t(key, **kwargs):
+    """Return the explanation for ``key`` in the active language.
+
+    Falls back to English for an unknown language or a missing key.
+    """
+    table = MESSAGES.get(_language, MESSAGES[_DEFAULT])
+    template = table.get(key) or MESSAGES[_DEFAULT][key]
+    return template.format(**kwargs)
+
+
+if __name__ == "__main__":
+    # ponytail: smallest check that the two fallback levels and formatting hold.
+    assert t("swapaxes.swap", a=0, b=2) == "Swapping axes 0 and 2."
+    set_language("de")  # no German table yet, falls back to the en table
+    assert t("common.result_shape", shape="(2,)") == "Result shape: (2,)"
+    MESSAGES["de"] = {"swapaxes.swap": "Tausche Achsen {a} und {b}."}
+    assert t("swapaxes.swap", a=0, b=2) == "Tausche Achsen 0 und 2."
+    # missing key in a partial table still falls back to en
+    assert t("common.result_shape", shape="(2,)") == "Result shape: (2,)"
+    del MESSAGES["de"]
+    set_language("en")
+    print("ok")

--- a/src/rainbow_tensor/indexing.py
+++ b/src/rainbow_tensor/indexing.py
@@ -12,6 +12,7 @@ like their nonzero integer arrays; see :func:`advanced_index`.
 import itertools
 from math import prod
 
+from .explanations import t
 from .ops import broadcast_result_shape, broadcast_source_coord
 from .shape import coordinates, format_shape
 
@@ -227,25 +228,21 @@ def explain_index(shape, index):
     """Build the lines explaining how an index transforms a shape."""
     tokens = validate_index(index, shape)
     lines = [
-        f"Original shape: {format_shape(shape)}",
-        f"Index: {format_index(index)}",
-        f"Result shape: {format_shape(result_shape(shape, index))}",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("common.index", index=format_index(index)),
+        t("common.result_shape", shape=format_shape(result_shape(shape, index))),
     ]
     axis = 0  # source axis
     out = 0  # result axis position
     for tok in tokens:
         if tok is None:
-            lines.append(f"A new size 1 axis is inserted by None at result position {out}.")
+            lines.append(t("index.new_axis", pos=out))
             out += 1
             continue
         if isinstance(tok, int):
-            lines.append(
-                f"Axis {axis} is removed because integer index {tok} is used."
-            )
+            lines.append(t("index.axis_removed", axis=axis, index=tok))
         else:
-            lines.append(
-                f"Axis {axis} is kept because slice {format_slice(tok)} is used."
-            )
+            lines.append(t("index.axis_kept", axis=axis, slice=format_slice(tok)))
             out += 1
         axis += 1
     return lines
@@ -293,10 +290,10 @@ def _mask_index(shape, mask):
     result = (len(selected),)
     plural = "s" if len(selected) != 1 else ""
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        "Advanced indexing with a boolean mask.",
-        f"The mask keeps {len(selected)} element{plural} where it is True.",
-        f"Result shape: {format_shape(result)}",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("index.mask"),
+        t("index.mask_keeps", count=len(selected), plural=plural),
+        t("common.result_shape", shape=format_shape(result)),
     ]
     return selected, result, explanation
 
@@ -425,15 +422,18 @@ def _array_index(shape, index):
     count = prod(bshape)
     axes_text = ", ".join(str(a) for a in arr_axes)
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        f"Index: {format_index(index)}",
-        "Advanced indexing with integer arrays.",
-        f"Axes {axes_text} gather {count} position{'s' if count != 1 else ''} "
-        f"in shape {format_shape(bshape)}.",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("common.index", index=format_index(index)),
+        t("index.arrays"),
+        t(
+            "index.gather",
+            axes=axes_text,
+            count=count,
+            plural="s" if count != 1 else "",
+            shape=format_shape(bshape),
+        ),
     ]
     if not contiguous:
-        explanation.append(
-            "A slice separates the gathered axes, so the gathered axis moves to the front."
-        )
-    explanation.append(f"Result shape: {format_shape(result_shape_)}")
+        explanation.append(t("index.slice_separates"))
+    explanation.append(t("common.result_shape", shape=format_shape(result_shape_)))
     return selected, result_shape_, explanation

--- a/src/rainbow_tensor/notebook.py
+++ b/src/rainbow_tensor/notebook.py
@@ -10,6 +10,7 @@ from itertools import product
 from math import prod
 
 from .backends import value_at_coordinate
+from .explanations import t
 from .indexing import (
     advanced_index,
     explain_index,
@@ -152,12 +153,26 @@ def _preview_explanation(shapes, theme):
         hidden = [axis for axis, (size, limit) in enumerate(zip(shape, limits)) if size > limit]
         if not hidden:
             continue
-        name = "tensor" if len(shapes) == 1 else f"tensor {i}"
-        lines.append(
-            f"Large preview for {name} {format_shape(shape)} draws at most "
-            f"{theme.max_visible_cells} real cells from {prod(shape)} total."
-        )
-        lines.append(f"Hidden axes {hidden} keep the head, selected positions, and tail.")
+        if len(shapes) == 1:
+            lines.append(
+                t(
+                    "preview.large_single",
+                    shape=format_shape(shape),
+                    max=theme.max_visible_cells,
+                    total=prod(shape),
+                )
+            )
+        else:
+            lines.append(
+                t(
+                    "preview.large_multi",
+                    i=i,
+                    shape=format_shape(shape),
+                    max=theme.max_visible_cells,
+                    total=prod(shape),
+                )
+            )
+        lines.append(t("preview.hidden", hidden=hidden))
     return lines
 
 
@@ -360,9 +375,9 @@ def reshape(array, new_shape, theme=None, precision=2, renderer=None):
         return source_value(reshape_source_coord(coord, old, new))
 
     explanation = [
-        f"Original shape: {format_shape(old)}",
-        f"New shape: {format_shape(new)}",
-        "Values keep their row major order, so element k stays element k.",
+        t("common.original_shape", shape=format_shape(old)),
+        t("common.new_shape", shape=format_shape(new)),
+        t("reshape.row_major"),
     ] + _preview_explanation([old, new], theme)
     panels = [
         {
@@ -408,10 +423,10 @@ def transpose(array, axes=None, theme=None, precision=2, renderer=None):
         return result_theme.axis_color(axis) if axis < len(result) - 1 else theme.text_muted
 
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        f"Axes order: {perm}",
-        f"Result shape: {format_shape(result)}",
-        "Each axis keeps its colour as it moves to its new position.",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("common.axes_order", order=perm),
+        t("common.result_shape", shape=format_shape(result)),
+        t("transpose.keep_colour"),
     ] + _preview_explanation([shape, result], theme)
     panels = [
         {
@@ -461,11 +476,11 @@ def swapaxes(array, axis1, axis2, theme=None, precision=2, renderer=None):
         return result_theme.axis_color(axis) if axis < len(result) - 1 else theme.text_muted
 
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        f"Swapping axes {axis1_r} and {axis2_r}.",
-        f"Axes order: {perm}",
-        f"Result shape: {format_shape(result)}",
-        "The two moved axes keep their source colours in the result.",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("swapaxes.swap", a=axis1_r, b=axis2_r),
+        t("common.axes_order", order=perm),
+        t("common.result_shape", shape=format_shape(result)),
+        t("swapaxes.keep_colour"),
     ] + _preview_explanation([shape, result], theme)
     panels = [
         {
@@ -516,11 +531,11 @@ def moveaxis(array, source, destination, theme=None, precision=2, renderer=None)
         return result_theme.axis_color(axis) if axis < len(result) - 1 else theme.text_muted
 
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        f"Moving axes {source} to {destination}.",
-        f"Axes order: {order}",
-        f"Result shape: {format_shape(result)}",
-        "Each moved axis keeps its source colour in the result.",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("moveaxis.move", source=source, destination=destination),
+        t("common.axes_order", order=order),
+        t("common.result_shape", shape=format_shape(result)),
+        t("moveaxis.keep_colour"),
     ] + _preview_explanation([shape, result], theme)
     panels = [
         {
@@ -591,13 +606,13 @@ def squeeze(array, axis=None, theme=None, precision=2, renderer=None):
     )
 
     removed_line = (
-        f"Removing size one axes {list(removed)}." if removed else "No size one axes to remove."
+        t("squeeze.removing", axes=list(removed)) if removed else t("squeeze.none")
     )
     explanation = [
-        f"Original shape: {format_shape(shape)}",
+        t("common.original_shape", shape=format_shape(shape)),
         removed_line,
-        f"Result shape: {format_shape(result)}",
-        "Each surviving axis keeps its colour, and the removed size one axes are marked.",
+        t("common.result_shape", shape=format_shape(result)),
+        t("squeeze.keep_colour"),
     ] + _preview_explanation([shape, display_result], theme)
     panels = [
         {
@@ -658,10 +673,10 @@ def expand_dims(array, axis, theme=None, precision=2, renderer=None):
         return result_theme.axis_color(axis) if axis < len(result) - 1 else theme.text_muted
 
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        f"Inserting size one axes at {list(inserted)}.",
-        f"Result shape: {format_shape(result)}",
-        "Each existing axis keeps its colour, and the inserted size one axes are marked.",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("expand_dims.inserting", axes=list(inserted)),
+        t("common.result_shape", shape=format_shape(result)),
+        t("expand_dims.keep_colour"),
     ] + _preview_explanation([shape, result], theme)
     panels = [
         {
@@ -731,11 +746,10 @@ def matmul(a, b, theme=None, precision=2, renderer=None):
     rows = "n/a" if len(a_shape) == 1 else a_shape[-2]
     cols = "n/a" if len(b_shape) == 1 else b_shape[-1]
     explanation = [
-        f"Operand shapes: {format_shape(a_shape)} @ {format_shape(b_shape)}",
-        f"Left rows: {rows}, right columns: {cols}, shared inner axis: {inner}.",
-        f"Result shape: {format_shape(result)}",
-        "The shared inner axis is marked, and the highlighted row and column "
-        "combine into the first output element.",
+        t("matmul.operands", a=format_shape(a_shape), b=format_shape(b_shape)),
+        t("matmul.dims", rows=rows, cols=cols, inner=inner),
+        t("common.result_shape", shape=format_shape(result)),
+        t("matmul.combine"),
     ] + _preview_explanation([a_shape, b_shape, display_result], theme)
     panels = [
         {
@@ -796,12 +810,10 @@ def repeat(array, repeats, axis=0, theme=None, precision=2, renderer=None):
         return _operand_tint(theme, source_positions[coord[axis]])
 
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        f"Repeating {repeats} along axis {axis}.",
-        f"Result shape: {format_shape(result)}",
-        "Each source element is copied into its own run of result cells, so "
-        "repeat materialises real copies, unlike broadcast which stretches a "
-        "size one axis virtually.",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("repeat.repeating", repeats=repeats, axis=axis),
+        t("common.result_shape", shape=format_shape(result)),
+        t("repeat.copies"),
     ] + _preview_explanation([shape, result], theme)
     panels = [
         {
@@ -853,11 +865,10 @@ def take(array, indices, axis=0, theme=None, precision=2, renderer=None):
         return _operand_tint(theme, resolved[coord[axis]])
 
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        f"Taking indices {list(indices)} along axis {axis}.",
-        f"Result shape: {format_shape(result)}",
-        "Each result slice copies a source slice, so repeated indices repeat a "
-        "slice and reordered indices reorder them.",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("take.taking", indices=list(indices), axis=axis),
+        t("common.result_shape", shape=format_shape(result)),
+        t("take.copies"),
     ] + _preview_explanation([shape, result], theme)
     panels = [
         {
@@ -1049,14 +1060,14 @@ def einsum(subscripts, *arrays, theme=None, precision=2, renderer=None):
     input_text = ", ".join("".join(labels) or "scalar" for labels in input_axes)
     output_text = "".join(output_axes) or "scalar"
     if contracted:
-        contracted_line = f"Contracted labels: {', '.join(contracted)}"
+        contracted_line = t("einsum.contracted", labels=", ".join(contracted))
     else:
-        contracted_line = "No labels are contracted."
+        contracted_line = t("einsum.none_contracted")
     explanation = [
-        f"Operand subscripts: {input_text}",
-        f"Output subscript: {output_text}",
+        t("einsum.operand_subscripts", subscripts=input_text),
+        t("einsum.output_subscript", subscript=output_text),
         contracted_line,
-        f"Result shape: {format_shape(result)}",
+        t("common.result_shape", shape=format_shape(result)),
     ] + _preview_explanation([*shapes, display_result], theme)
     content = renderer.render_panels(
         panels=panels,
@@ -1127,12 +1138,11 @@ def _reduce(array, axis, op_name, combine, theme, precision, renderer):
         return values[() if not result else coord]
 
     explanation = [
-        f"Original shape: {format_shape(shape)}",
-        f"Reducing axis {axis} with {op_name}.",
-        f"Result shape: {format_shape(result)}",
-        f"Each result element combines {shape[axis]} values from axis {axis}.",
-        "Values that fold into the same result share one background with that "
-        "result element, and the first group is highlighted.",
+        t("common.original_shape", shape=format_shape(shape)),
+        t("reduce.reducing", axis=axis, op=op_name),
+        t("common.result_shape", shape=format_shape(result)),
+        t("reduce.combines", count=shape[axis], axis=axis),
+        t("reduce.share_background"),
     ] + _preview_explanation([shape, disp], theme)
     panels = [
         {
@@ -1275,10 +1285,10 @@ def concatenate(arrays, axis=0, theme=None, precision=2, renderer=None):
 
     sizes = ", ".join(format_shape(s) for s in shapes)
     explanation = [
-        f"Operand shapes: {sizes}",
-        f"Joining along axis {axis_r}.",
-        f"Result shape: {format_shape(result)}",
-        "Each operand keeps its tint, so the seam along the joined axis is clear.",
+        t("concatenate.operands", shapes=sizes),
+        t("concatenate.joining", axis=axis_r),
+        t("common.result_shape", shape=format_shape(result)),
+        t("concatenate.seam"),
     ]
     return _combine(
         arrays, shapes, result, origin_fn, "concatenate", explanation, theme, precision, renderer
@@ -1302,10 +1312,10 @@ def stack(arrays, axis=0, theme=None, precision=2, renderer=None):
         return stack_source(coord, axis_r, ndim)
 
     explanation = [
-        f"Operand shape: {format_shape(shapes[0])}",
-        f"Stacking {len(arrays)} tensors on a new axis {axis_r}.",
-        f"Result shape: {format_shape(result)}",
-        "The new axis indexes the operands, each kept in its own tint.",
+        t("stack.operand", shape=format_shape(shapes[0])),
+        t("stack.stacking", count=len(arrays), axis=axis_r),
+        t("common.result_shape", shape=format_shape(result)),
+        t("stack.new_axis"),
     ]
     return _combine(
         arrays, shapes, result, origin_fn, "stack", explanation, theme, precision, renderer
@@ -1358,15 +1368,15 @@ def broadcast(a, b, theme=None, precision=2, renderer=None):
     def axes_line(i):
         ax = broadcast_stretched_axes(shapes[i], result)
         if ax:
-            return f"operand {i} {format_shape(shapes[i])} stretches axes {ax}"
-        return f"operand {i} {format_shape(shapes[i])} already matches"
+            return t("broadcast.stretches", i=i, shape=format_shape(shapes[i]), axes=ax)
+        return t("broadcast.matches", i=i, shape=format_shape(shapes[i]))
 
     explanation = [
-        f"Operand shapes: {format_shape(shapes[0])} and {format_shape(shapes[1])}",
+        t("broadcast.operands", a=format_shape(shapes[0]), b=format_shape(shapes[1])),
         axes_line(0),
         axes_line(1),
-        f"Result shape: {format_shape(result)}",
-        "A stretched axis repeats one value, so both operands fill the result shape.",
+        t("common.result_shape", shape=format_shape(result)),
+        t("broadcast.fill"),
     ] + _preview_explanation([*shapes, result], theme)
     content = renderer.render_panels(
         panels=panels,

--- a/src/rainbow_tensor/renderers.py
+++ b/src/rainbow_tensor/renderers.py
@@ -5,6 +5,7 @@ renderer interface here, which gives later HTML or canvas renderers a stable
 entry point without moving shape maths into a display backend.
 """
 
+from . import config
 from .render_svg import render_panels, render_svg
 
 
@@ -25,7 +26,7 @@ class SvgRenderer:
 
 SVG = SvgRenderer()
 _RENDERERS = {SVG.name: SVG}
-_default_renderer = SVG
+# The mutable default renderer lives in ``config``; ``None`` there means SVG.
 
 
 def register_renderer(renderer):
@@ -41,7 +42,7 @@ def register_renderer(renderer):
 def resolve_renderer(renderer=None):
     """Resolve a renderer object, a renderer name, or ``None``."""
     if renderer is None:
-        return _default_renderer
+        return config.default_renderer if config.default_renderer is not None else SVG
     if isinstance(renderer, str):
         try:
             return _RENDERERS[renderer]
@@ -56,14 +57,13 @@ def resolve_renderer(renderer=None):
 
 def get_default_renderer():
     """Return the current default renderer."""
-    return _default_renderer
+    return config.default_renderer if config.default_renderer is not None else SVG
 
 
 def set_default_renderer(renderer):
     """Set the default renderer used when no call passes one."""
-    global _default_renderer
-    _default_renderer = resolve_renderer(renderer)
-    return _default_renderer
+    config.default_renderer = resolve_renderer(renderer)
+    return config.default_renderer
 
 
 def _check_renderer(renderer):

--- a/src/rainbow_tensor/theme.py
+++ b/src/rainbow_tensor/theme.py
@@ -16,6 +16,8 @@ later milestone.
 
 from dataclasses import dataclass, field, replace
 
+from . import config
+
 # Multi-word font names are wrapped in single quotes so the value stays valid
 # inside a double-quoted SVG attribute. Double quotes here would break the XML.
 SANS_FAMILY = (
@@ -143,10 +145,8 @@ DARK = Theme(
 )
 
 _PRESETS = {LIGHT.name: LIGHT, DARK.name: DARK}
-_default_theme = LIGHT
-# A global axis colour ramp applied to the default theme for calls that pass no
-# theme of their own. ``None`` keeps each theme's built-in ramp.
-_default_axis_colors = None
+# The mutable default theme and axis ramp live in ``config``; ``None`` there
+# means use ``LIGHT`` and each theme's own ramp.
 
 
 def register_theme(theme):
@@ -164,9 +164,10 @@ def resolve_theme(theme):
     the registered presets. A :class:`Theme` is returned unchanged.
     """
     if theme is None:
-        if _default_axis_colors is not None:
-            return _default_theme.variant(axis_colors=_default_axis_colors)
-        return _default_theme
+        base = config.default_theme if config.default_theme is not None else LIGHT
+        if config.default_axis_colors is not None:
+            return base.variant(axis_colors=config.default_axis_colors)
+        return base
     if isinstance(theme, Theme):
         return theme
     if isinstance(theme, str):
@@ -184,19 +185,18 @@ def resolve_theme(theme):
 
 def get_default_theme():
     """Return the current module default theme."""
-    return _default_theme
+    return config.default_theme if config.default_theme is not None else LIGHT
 
 
 def set_default_theme(theme):
     """Set the module default theme used when a call passes no theme."""
-    global _default_theme
-    _default_theme = resolve_theme(theme)
-    return _default_theme
+    config.default_theme = resolve_theme(theme)
+    return config.default_theme
 
 
 def get_default_axis_colors():
     """Return the global axis colour ramp, or ``None`` when none is set."""
-    return _default_axis_colors
+    return config.default_axis_colors
 
 
 def set_default_axis_colors(colors):
@@ -208,14 +208,13 @@ def set_default_axis_colors(colors):
     a hard override. Pass ``None`` to clear it and fall back to each theme's
     built-in ramp.
     """
-    global _default_axis_colors
     if colors is None:
-        _default_axis_colors = None
+        config.default_axis_colors = None
         return None
     ramp = tuple(colors)
     if not ramp:
         raise ValueError("axis colours must be a non-empty sequence of colour strings")
     if not all(isinstance(c, str) for c in ramp):
         raise TypeError("axis colours must all be colour strings")
-    _default_axis_colors = ramp
-    return _default_axis_colors
+    config.default_axis_colors = ramp
+    return config.default_axis_colors

--- a/tests/test_explanations.py
+++ b/tests/test_explanations.py
@@ -1,0 +1,43 @@
+"""Tests for the centralised explanation text and language switching."""
+
+import pytest
+
+from rainbow_tensor import get_language, set_language, swapaxes
+from rainbow_tensor.explanations import MESSAGES, t
+
+
+@pytest.fixture(autouse=True)
+def _restore_language():
+    yield
+    set_language("en")
+    MESSAGES.pop("xx", None)
+
+
+def test_every_translation_only_uses_known_keys():
+    # A typo in a translated key would silently fall back to en forever, so guard it.
+    en_keys = set(MESSAGES["en"])
+    for lang, table in MESSAGES.items():
+        extra = set(table) - en_keys
+        assert not extra, f"{lang} has keys absent from en: {extra}"
+
+
+def test_unknown_language_falls_back_to_en():
+    set_language("nope")
+    assert t("common.result_shape", shape="(2,)") == "Result shape: (2,)"
+
+
+def test_partial_translation_falls_back_per_key():
+    MESSAGES["xx"] = {"swapaxes.swap": "swap {a} {b}"}
+    set_language("xx")
+    assert t("swapaxes.swap", a=0, b=2) == "swap 0 2"
+    # key missing from the xx table still resolves through en
+    assert t("common.result_shape", shape="(2,)") == "Result shape: (2,)"
+
+
+def test_set_language_changes_a_real_visual():
+    np = pytest.importorskip("numpy")
+    MESSAGES["xx"] = {"swapaxes.swap": "Tausche {a} und {b}."}
+    set_language("xx")
+    assert get_language() == "xx"
+    visual = swapaxes(np.arange(24).reshape(2, 3, 4), 0, 2)
+    assert "Tausche 0 und 2." in visual.text


### PR DESCRIPTION
Closes #86.

Centralises the notebook explanation text and adds language support, then
gathers all mutable global defaults into one config module.

## What changed

- New `explanations.py` holds every caption as a keyed template, with
  `set_language`/`get_language` and a two-level English fallback (unknown
  language falls back to the `en` table, a missing key falls back to its `en`
  string).
- `notebook.py` and `indexing.py` route all visual captions through `t(...)`;
  validation and exception messages are left as is.
- `set_language`/`get_language` are exposed in the public API.
- New `config.py` owns all mutable defaults (theme, axis colours, renderer,
  language). Domain modules delegate to it. Object defaults are `None`
  sentinels, so `config.py` imports nothing and cannot form an import cycle.
- User guide notes how to set the language.

## Checks

- `pytest`: 338 passed, 3 skipped
- `ruff check .`: clean
- `python -m build`: builds the wheel and sdist
